### PR TITLE
fix: remove unused tempfile import in tests

### DIFF
--- a/gestalt_core/src/application/config.rs
+++ b/gestalt_core/src/application/config.rs
@@ -222,7 +222,6 @@ pub fn load_config(config_paths: &[&Path]) -> Result<GestaltConfig, ConfigError>
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::TempDir;
     
     #[test]
     fn test_default_config() {


### PR DESCRIPTION
Remove unused 	empfile::TempDir import that was causing compilation error.