### PR TITLE
fix: remove duplicate imports in gestalt_timeline services

### DIFF
--- a/gestalt_timeline/src/services/mod.rs
+++ b/gestalt_timeline/src/services/mod.rs
@@ -17,8 +17,6 @@ pub use llm::{Cognition, LLMResponse, LLMService, OrchestrationAction};
 pub use project::ProjectService;
 pub use task::TaskService;
 pub use timeline::TimelineService;
-pub use task::TaskService;
-pub use timeline::TimelineService;
 pub use watch::WatchService;
 pub use telegram::TelegramService;
 pub mod runtime;


### PR DESCRIPTION
## Fix

Remove duplicate imports in gestalt_timeline/src/services/mod.rs:
- pub use task::TaskService; (duplicate)
- pub use timeline::TimelineService; (duplicate)

This was causing E0252 compilation error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed duplicate module exports to improve codebase clarity and reduce redundancy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->