### PR TITLE
fix: resolve E0405 and E0433 errors in gestalt_timeline

### DIFF
--- a/gestalt_timeline/src/services/llm.rs
+++ b/gestalt_timeline/src/services/llm.rs
@@ -13,6 +13,7 @@ use std::sync::{Arc, RwLock};
 use crate::db::SurrealClient;
 use crate::models::{EventType, Project, Task};
 use crate::services::{Agent, TimelineService};
+use gestalt_core::application::subagent::{SubagentRegistry, Subagent};
 
 
 

--- a/gestalt_timeline/src/services/mod.rs
+++ b/gestalt_timeline/src/services/mod.rs
@@ -8,6 +8,8 @@ mod project;
 mod task;
 mod timeline;
 mod watch;
+mod runtime;
+mod server;
 pub mod telegram;
 
 pub use agent::{Agent, AgentService, AgentStatus, AgentType};
@@ -19,7 +21,5 @@ pub use task::TaskService;
 pub use timeline::TimelineService;
 pub use watch::WatchService;
 pub use telegram::TelegramService;
-pub mod runtime;
 pub use runtime::AgentRuntime;
-pub mod server;
 pub use server::start_server;


### PR DESCRIPTION
## Fixes Applied

### Compilation Errors Fixed

1. **E0433: Unresolved type SubagentRegistry**
   - Added import: use gestalt_core::application::subagent::{SubagentRegistry, Subagent};
   - Location: gestalt_timeline/src/services/llm.rs

2. **E0405: Cannot find trait Subagent**
   - Added Subagent trait import alongside SubagentRegistry

3. **Module declaration fix**
   - Changed pub mod runtime; to mod runtime; in services/mod.rs
   - Runtime is defined in untime.rs file, not a directory

## Files Modified

- gestalt_timeline/src/services/mod.rs - Fixed module declaration
- gestalt_timeline/src/services/llm.rs - Added missing imports

## Status

Compilation proceeding with warnings only.