### PR TITLE
fix: add subagents field to LLMService struct

### DIFF
--- a/gestalt_timeline/src/services/llm.rs
+++ b/gestalt_timeline/src/services/llm.rs
@@ -35,6 +35,7 @@ pub struct LLMService {
     db: SurrealClient,
     timeline: TimelineService,
     model_id: Arc<RwLock<String>>,
+    subagents: Arc<SubagentRegistry>,
 }
 
 #[async_trait::async_trait]


### PR DESCRIPTION
## Fix Applied

### Issue
The LLMService struct was missing the subagents field, causing compilation errors.

### Solution
Added subagents: Arc<SubagentRegistry> field to the LLMService struct definition.

### Files Modified
- gestalt_timeline/src/services/llm.rs - Added subagents field to struct

### Status
Compilation proceeding with warnings only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced the LLM service with subagent routing capabilities, enabling message routing to registered subagents for improved task handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->