### PR TITLE
Feat (CLI): Invisible Background Processes (Daemons)

### DIFF
--- a/gestalt_timeline/src/cli/commands.rs
+++ b/gestalt_timeline/src/cli/commands.rs
@@ -223,6 +223,9 @@ pub enum Commands {
         /// Port for REST API (default: 3000)
         #[arg(long, default_value_t = 3000)]
         port: u16,
+        /// Run as a background daemon
+        #[arg(long)]
+        daemon: bool,
     },
 
     /// Queue a task from the CLI for autonomous background execution


### PR DESCRIPTION
This change implements true background process (daemon) support for the Gestalt CLI. 

Key improvements:
- The `gestalt nexus` command now accepts a `--daemon` flag. When provided, the process will re-execute itself in the background, hide its terminal window on Windows using `CREATE_NO_WINDOW`, and redirect all output to `gestalt-nexus.log`.
- Sub-agents spawned via `gestalt agent spawn` are now also launched with hidden windows on Windows.
- A new logging mechanism for sub-agents was added to `DispatcherService`. It captures both `stdout` and `stderr` and writes them to a file named `subagent-<uuid>.log` in addition to emitting them to the universal timeline. This ensures that even if the timeline service is unavailable or the agent fails early, its logs are preserved on disk.
- The sub-agent logging loop was refined to use `tokio::select!` with correctly handled stream termination and non-blocking asynchronous I/O via `tokio::fs`.

Fixes #27

---
*PR created automatically by Jules for task [15622048662540059386](https://jules.google.com/task/15622048662540059386) started by @iberi22*