### PR TITLE
Protocol Synchronization (Timeline to Markdown)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -485,21 +485,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "assert_cmd"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcbb6924530aa9e0432442af08bbcafdad182db80d2e560da42a6d442535bf85"
-dependencies = [
- "anstyle",
- "bstr",
- "libc",
- "predicates",
- "predicates-core",
- "predicates-tree",
- "wait-timeout",
-]
-
-[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2499,12 +2484,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
-name = "difflib"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
-
-[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3171,15 +3150,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "float-cmp"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "float_next_after"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3834,7 +3804,6 @@ name = "gestalt_timeline"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "assert_cmd",
  "async-trait",
  "aws-config",
  "aws-sdk-bedrock",
@@ -3849,7 +3818,6 @@ dependencies = [
  "gestalt_core",
  "oauth2",
  "open",
- "predicates",
  "reqwest 0.11.27",
  "rustyline",
  "serde",
@@ -5580,12 +5548,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "normalize-line-endings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
-
-[[package]]
 name = "ntapi"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6649,36 +6611,6 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
-
-[[package]]
-name = "predicates"
-version = "3.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d19ee57562043d37e82899fade9a22ebab7be9cef5026b07fda9cdd4293573"
-dependencies = [
- "anstyle",
- "difflib",
- "float-cmp",
- "normalize-line-endings",
- "predicates-core",
- "regex",
-]
-
-[[package]]
-name = "predicates-core"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "727e462b119fe9c93fd0eb1429a5f7647394014cf3c04ab2c0350eeb09095ffa"
-
-[[package]]
-name = "predicates-tree"
-version = "1.0.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72dd2d6d381dfb73a193c7fca536518d7caee39fc8503f74e7dc0be0531b425c"
-dependencies = [
- "predicates-core",
- "termtree",
-]
 
 [[package]]
 name = "presser"
@@ -8913,12 +8845,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termtree"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9769,15 +9695,6 @@ name = "vsimd"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"

--- a/gestalt_timeline/Cargo.toml
+++ b/gestalt_timeline/Cargo.toml
@@ -77,6 +77,6 @@ tokio-cron-scheduler = "0.13"
 tiktoken-rs = "0.6"
 
 [dev-dependencies]
-assert_cmd = "2.0"
-predicates = "3.0"
+# assert_cmd = "2.0"
+# predicates = "3.0"
 tempfile = "3.9"

--- a/gestalt_timeline/src/cli/commands.rs
+++ b/gestalt_timeline/src/cli/commands.rs
@@ -186,6 +186,27 @@ pub enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
+
+    /// Synchronize protocol states between SurrealDB and markdown files
+    #[command(name = "protocol-sync")]
+    ProtocolSync {
+        /// Project name
+        #[arg(short, long)]
+        project: String,
+
+        /// Path to the markdown file (default: .gitcore/planning/TASK.md)
+        #[arg(short, long, default_value = ".gitcore/planning/TASK.md")]
+        path: String,
+
+        /// Synchronize from markdown to database
+        #[arg(long)]
+        to_db: bool,
+
+        /// Synchronize from database to markdown
+        #[arg(long)]
+        to_markdown: bool,
+    },
+
     /// Start the Agent REST API server
     #[command(name = "server")]
     Server {

--- a/gestalt_timeline/src/db/surreal.rs
+++ b/gestalt_timeline/src/db/surreal.rs
@@ -91,8 +91,10 @@ impl SurrealClient {
             DEFINE FIELD created_by ON tasks TYPE string;
             DEFINE FIELD executed_by ON tasks TYPE option<string>;
             DEFINE FIELD duration_ms ON tasks TYPE option<int>;
+            DEFINE FIELD external_id ON tasks TYPE option<string>;
             DEFINE INDEX idx_project_id ON tasks FIELDS project_id;
             DEFINE INDEX idx_status ON tasks FIELDS status;
+            DEFINE INDEX idx_external_id ON tasks FIELDS external_id;
 
             DEFINE TABLE agents SCHEMAFULL;
             DEFINE FIELD name ON agents TYPE string;
@@ -230,6 +232,18 @@ impl SurrealClient {
     /// Access the underlying Surreal client.
     pub fn client(&self) -> Arc<Surreal<Any>> {
         self.db.clone()
+    }
+
+    /// Connect to an in-memory database (convenience for tests).
+    pub async fn connect_mem() -> Result<Self> {
+        Self::connect(&crate::config::DatabaseSettings {
+            url: "mem://".to_string(),
+            user: "root".to_string(),
+            pass: "root".to_string(),
+            namespace: "test".to_string(),
+            database: "test".to_string(),
+        })
+        .await
     }
     /// Delete a record.
     pub async fn delete(&self, table: &str, id: &str) -> Result<()> {

--- a/gestalt_timeline/src/services/mod.rs
+++ b/gestalt_timeline/src/services/mod.rs
@@ -11,6 +11,7 @@ mod runtime;
 mod index;
 pub mod file_manager;
 mod server;
+pub mod protocol_sync;
 mod task;
 pub mod task_queue;
 pub mod telegram;
@@ -27,6 +28,7 @@ pub use memory::{MemoryFragment, MemoryService};
 pub use index::IndexService;
 pub use file_manager::{FileManager, FileManagerActor, FileState};
 pub use project::ProjectService;
+pub use protocol_sync::ProtocolSyncService;
 pub use reviewer_merge_agent::{
     spawn_reviewer_agent, ReviewResult, ReviewerMergeAgent, ReviewerMessage,
 };

--- a/gestalt_timeline/src/services/protocol_sync.rs
+++ b/gestalt_timeline/src/services/protocol_sync.rs
@@ -1,0 +1,256 @@
+//! Protocol Synchronization Service
+//!
+//! Synchronizes SurrealDB states with local markdown files (e.g. TASK.md).
+
+use anyhow::{Context, Result};
+use std::path::Path;
+use tokio::fs;
+use crate::models::{Task, TaskStatus};
+use crate::db::SurrealClient;
+use crate::services::TimelineService;
+use crate::models::EventType;
+
+pub struct ProtocolSyncService {
+    db: SurrealClient,
+    timeline: TimelineService,
+}
+
+impl ProtocolSyncService {
+    pub fn new(db: SurrealClient, timeline: TimelineService) -> Self {
+        Self { db, timeline }
+    }
+
+    /// Synchronizes tasks from a markdown file into the database.
+    pub async fn sync_from_markdown(&self, path: &Path, project_name: &str, agent_id: &str) -> Result<()> {
+        let content = fs::read_to_string(path).await
+            .with_context(|| format!("Failed to read markdown file: {:?}", path))?;
+
+        let tasks = self.parse_tasks_from_markdown(&content);
+
+        // Get project ID
+        let query = "SELECT * FROM projects WHERE name = $name LIMIT 1";
+        let projects: Vec<crate::models::Project> = self.db.query_with(query, ("name", project_name)).await?;
+        let project = projects.into_iter().next().context("Project not found")?;
+        let project_id_str = project.id.as_ref().map(|t| t.to_string()).unwrap_or_default();
+
+        for mut markdown_task in tasks {
+            markdown_task.project_id = project_id_str.clone();
+            markdown_task.created_by = agent_id.to_string();
+
+            let ext_id = markdown_task.external_id.clone().unwrap_or_default();
+            println!("Syncing markdown task: ID={}, Desc={}", ext_id, markdown_task.description);
+
+            // Check if task already exists by external_id
+            let query = "SELECT * FROM tasks WHERE external_id = $ext_id AND project_id = $proj_id LIMIT 1";
+            let mut vars = std::collections::HashMap::new();
+            vars.insert("ext_id", ext_id.clone());
+            vars.insert("proj_id", project_id_str.clone());
+
+            let existing: Vec<Task> = self.db.query_with(query, vars).await?;
+
+            if let Some(existing_task) = existing.into_iter().next() {
+                // Update existing task if status changed
+                if existing_task.status != markdown_task.status || existing_task.description != markdown_task.description {
+                    let task_id = existing_task.id.as_ref().unwrap();
+                    let task_id_str = match &task_id.id {
+                        surrealdb::sql::Id::String(s) => s.clone(),
+                        _ => task_id.to_string(),
+                    };
+
+                    self.db.update("tasks", &task_id_str, &markdown_task).await?;
+
+                    self.timeline.emit_task_event(
+                        agent_id,
+                        EventType::TaskUpdated,
+                        &project_id_str,
+                        &task_id_str
+                    ).await?;
+                }
+            } else {
+                // Create new task
+                let created: Task = self.db.create("tasks", &markdown_task).await?;
+                let task_id_str = created.id.as_ref().unwrap().to_string();
+
+                self.timeline.emit_task_event(
+                    agent_id,
+                    EventType::TaskCreated,
+                    &project_id_str,
+                    &task_id_str
+                ).await?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Synchronizes task statuses from the database back into the markdown file.
+    pub async fn sync_to_markdown(&self, path: &Path, project_name: &str) -> Result<()> {
+        let content = fs::read_to_string(path).await
+            .with_context(|| format!("Failed to read markdown file: {:?}", path))?;
+
+        // Get project ID
+        let query = "SELECT * FROM projects WHERE name = $name LIMIT 1";
+        let projects: Vec<crate::models::Project> = self.db.query_with(query, ("name", project_name)).await?;
+        let project = projects.into_iter().next().context("Project not found")?;
+        let project_id_str = project.id.as_ref().map(|t| t.to_string()).unwrap_or_default();
+
+        // Get all tasks for this project
+        let query = "SELECT * FROM tasks WHERE project_id = $proj_id";
+        let db_tasks: Vec<Task> = self.db.query_with(query, ("proj_id", &project_id_str)).await?;
+
+        let updated_content = self.update_markdown_with_tasks(&content, &db_tasks);
+
+        if content != updated_content {
+            fs::write(path, updated_content).await?;
+        }
+
+        Ok(())
+    }
+
+    fn parse_tasks_from_markdown(&self, content: &str) -> Vec<Task> {
+        let mut tasks = Vec::new();
+        let mut in_table = false;
+        let mut headers = Vec::new();
+
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.starts_with('|') {
+                let parts: Vec<String> = trimmed
+                    .split('|')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+
+                if parts.is_empty() { continue; }
+
+                if !in_table {
+                    // Possible header
+                    if parts.iter().any(|p| p.to_lowercase() == "id") && parts.iter().any(|p| p.to_lowercase() == "status") {
+                        headers = parts;
+                        in_table = true;
+                    }
+                    continue;
+                }
+
+                if trimmed.contains("---|") || trimmed.contains(":---|") {
+                    continue; // Skip separator
+                }
+
+                // Table row
+                let mut external_id = None;
+                let mut status = TaskStatus::Pending;
+                let mut description = String::new();
+
+                for (i, part) in parts.iter().enumerate() {
+                    if i >= headers.len() { break; }
+                    let header = headers[i].to_lowercase();
+                    if header == "id" {
+                        external_id = Some(part.clone());
+                    } else if header == "status" {
+                        status = match part.to_lowercase().as_str() {
+                            p if p.contains('✅') || p.contains("completed") || p.contains("done") => TaskStatus::Completed,
+                            p if p.contains('🔄') || p.contains("running") || p.contains("inprogress") => TaskStatus::Running,
+                            p if p.contains('❌') || p.contains("failed") => TaskStatus::Failed,
+                            p if p.contains('⏳') || p.contains("pending") || p.contains("todo") => TaskStatus::Pending,
+                            _ => TaskStatus::Pending,
+                        };
+                    } else if header == "task" || header == "description" {
+                        description = part.clone();
+                    }
+                }
+
+                if let Some(id) = external_id {
+                    if !id.is_empty() && id != "ID" {
+                        let mut t = Task::new("", &description, "", Some(id.clone()));
+                        t.status = status;
+                        t.external_id = Some(id); // Ensure external_id is set
+                        tasks.push(t);
+                    }
+                }
+            } else {
+                in_table = false;
+            }
+        }
+        tasks
+    }
+
+    fn update_markdown_with_tasks(&self, content: &str, db_tasks: &[Task]) -> String {
+        let mut lines: Vec<String> = content.lines().map(|s| s.to_string()).collect();
+        let mut in_table = false;
+        let mut headers = Vec::new();
+
+        for i in 0..lines.len() {
+            let line = lines[i].trim();
+            if line.starts_with('|') {
+                let parts: Vec<String> = line
+                    .split('|')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+
+                if parts.is_empty() { continue; }
+
+                if !in_table {
+                    if parts.iter().any(|p| p.to_lowercase() == "id") && parts.iter().any(|p| p.to_lowercase() == "status") {
+                        headers = parts;
+                        in_table = true;
+                    }
+                    continue;
+                }
+
+                if line.contains("---|") || line.contains(":---|") {
+                    continue;
+                }
+
+                // Row
+                let mut external_id = None;
+                let mut status_idx = None;
+
+                for (j, part) in parts.iter().enumerate() {
+                    if j >= headers.len() { break; }
+                    let header = headers[j].to_lowercase();
+                    if header == "id" {
+                        external_id = Some(part.clone());
+                    } else if header == "status" {
+                        status_idx = Some(j);
+                    }
+                }
+
+                if let (Some(ext_id), Some(s_idx)) = (external_id, status_idx) {
+                    if let Some(db_task) = db_tasks.iter().find(|t| t.external_id.as_deref() == Some(&ext_id)) {
+                        let status_str = match db_task.status {
+                            TaskStatus::Completed => "✅ Completed",
+                            TaskStatus::Running => "🔄 Running",
+                            TaskStatus::Failed => "❌ Failed",
+                            TaskStatus::Cancelled => "🚫 Cancelled",
+                            TaskStatus::Pending => "⏳ Pending",
+                        };
+
+                        // Update the status in the row
+                        let mut new_parts: Vec<String> = line
+                            .split('|')
+                            .map(|s| s.trim().to_string())
+                            .collect();
+
+                        // split('|') on "| ID | Status |" gives ["", " ID ", " Status ", ""]
+                        // if headers were ["ID", "Status"], parts were ["ID", "Status"]
+                        // indices in parts: 0: ID, 1: Status
+                        // indices in new_parts: 0: "", 1: ID, 2: Status, 3: ""
+
+                        if s_idx + 1 < new_parts.len() {
+                            new_parts[s_idx + 1] = status_str.to_string();
+                            lines[i] = new_parts.join(" | ").trim().to_string();
+                            if !lines[i].starts_with('|') {
+                                lines[i] = format!("| {} |", lines[i]);
+                            }
+                        }
+                    }
+                }
+            } else {
+                in_table = false;
+            }
+        }
+
+        lines.join("\n")
+    }
+}

--- a/gestalt_timeline/src/tests.rs
+++ b/gestalt_timeline/src/tests.rs
@@ -117,7 +117,7 @@ mod task_tests {
 
     #[test]
     fn test_task_creation() {
-        let task = Task::new("project_1", "Fix bug in login", "agent_1");
+        let task = Task::new("project_1", "Fix bug in login", "agent_1", None);
 
         assert!(task.id.is_none());
         assert_eq!(task.project_id, "project_1");
@@ -171,7 +171,7 @@ mod serialization_tests {
 
     #[test]
     fn test_task_json_roundtrip() {
-        let task = Task::new("proj", "description", "agent");
+        let task = Task::new("proj", "description", "agent", None);
 
         let json = serde_json::to_string(&task).unwrap();
         let parsed: Task = serde_json::from_str(&json).unwrap();

--- a/gestalt_timeline/tests/test_protocol_sync.rs
+++ b/gestalt_timeline/tests/test_protocol_sync.rs
@@ -1,0 +1,64 @@
+use gestalt_timeline::db::SurrealClient;
+use gestalt_timeline::models::{Project, Task, TaskStatus};
+use gestalt_timeline::services::{ProtocolSyncService, TimelineService};
+use std::path::Path;
+use tempfile::tempdir;
+use tokio::fs;
+
+#[tokio::test]
+async fn test_protocol_sync_two_way() -> anyhow::Result<()> {
+    let dir = tempdir()?;
+    let task_md_path = dir.path().join("TASK.md");
+
+    let initial_content = r#"
+# 📋 TASK.md
+
+| ID | Task | Status |
+|----|------|--------|
+| T-01 | Fix auth bug | ⏳ Pending |
+| T-02 | Add tests | ✅ Completed |
+"#;
+    fs::write(&task_md_path, initial_content).await?;
+
+    let db = SurrealClient::connect_mem().await?;
+    let timeline = TimelineService::new(db.clone());
+    let sync_service = ProtocolSyncService::new(db.clone(), timeline.clone());
+
+    // Create project
+    let project = Project::new("test-project", "tester");
+    db.create("projects", &project).await?;
+
+    // 1. Sync from markdown to DB
+    sync_service.sync_from_markdown(&task_md_path, "test-project", "tester").await?;
+
+    // Verify tasks in DB
+    let tasks: Vec<Task> = db.select_all("tasks").await?;
+    println!("Tasks in DB: {:?}", tasks);
+    assert_eq!(tasks.len(), 2);
+
+    let t1 = tasks.iter().find(|t| t.external_id.as_deref() == Some("T-01")).unwrap();
+    assert_eq!(t1.status, TaskStatus::Pending);
+    assert_eq!(t1.description, "Fix auth bug");
+
+    let t2 = tasks.iter().find(|t| t.external_id.as_deref() == Some("T-02")).unwrap();
+    assert_eq!(t2.status, TaskStatus::Completed);
+
+    // 2. Update task in DB
+    let t1_id = match &t1.id.as_ref().unwrap().id {
+        surrealdb::sql::Id::String(s) => s.clone(),
+        id => id.to_string(),
+    };
+    let mut t1_updated = t1.clone();
+    t1_updated.status = TaskStatus::Running;
+    db.update("tasks", &t1_id, &t1_updated).await?;
+
+    // 3. Sync from DB to markdown
+    sync_service.sync_to_markdown(&task_md_path, "test-project").await?;
+
+    // Verify markdown content
+    let updated_content = fs::read_to_string(&task_md_path).await?;
+    assert!(updated_content.contains("| T-01 | Fix auth bug | 🔄 Running |"));
+    assert!(updated_content.contains("| T-02 | Add tests | ✅ Completed |"));
+
+    Ok(())
+}


### PR DESCRIPTION
Implemented two-way synchronization between SurrealDB and markdown planning artifacts. Added a new `protocol-sync` CLI command and updated the `Task` model and database schema to support external identifiers.

Fixes #26

---
*PR created automatically by Jules for task [9327920873286332301](https://jules.google.com/task/9327920873286332301) started by @iberi22*