### PR TITLE
fix(ci): correct backend binary name from gestalt_timeline to gestalt

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,8 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: neural-link-backend-windows
-          path: target/release/gestalt_timeline.exe
+          path: target/release/gestalt.exe
+          if-no-files-found: error
 
   build-cli:
     name: Build CLI
@@ -173,7 +174,7 @@ jobs:
 
       - name: Prepare CLI Binaries
         run: |
-          cp release-assets/neural-link-backend-windows/gestalt_timeline.exe release-assets/gestalt_timeline.exe
+          cp release-assets/neural-link-backend-windows/gestalt.exe release-assets/gestalt_timeline.exe
           cp release-assets/neural-link-app-android/app-release.apk release-assets/app-release.apk
           cp release-assets/cli-artifacts/gestalt-cli-windows/gestalt_cli.exe release-assets/gestalt-cli-windows.exe
           cp release-assets/cli-artifacts/gestalt-cli-linux/gestalt_cli release-assets/gestalt-cli-linux


### PR DESCRIPTION
## Summary

The Build and Release workflow was failing because the upload step was looking for a non-existent binary.

### Root Cause

The `gestalt_timeline` Cargo.toml defines the binary with:
```
[[bin]]
name = "gestalt"
path = "src/main.rs"
```

This means the binary is at `target/release/gestalt.exe`, NOT `target/release/gestalt_timeline.exe`.

The CI log showed:
```
No files were found with the provided path: target/release/gestalt_timeline.exe. No artifacts will be uploaded.
```

Because `if-no-files-found` defaults to `warn`, the job succeeded even though the artifact was never uploaded, causing the subsequent `create-release` job to fail.

### Fixes Applied

1. **Upload path corrected**: `target/release/gestalt_timeline.exe` -> `target/release/gestalt.exe`
2. **Fail-fast on missing artifact**: `if-no-files-found: error` (was using default `warn`)
3. **Release prep step**: Copies `gestalt.exe` as `gestalt_timeline.exe` for the release (preserves the release filename)

### Files Changed
- `.github/workflows/release.yml` - 3 changes

### Testing
- [x] Binary name verified against `gestalt_timeline/Cargo.toml`
- [x] CLI artifacts (gestalt_cli) already correct - only backend was wrong
- [x] Release binary naming preserved (gestalt_timeline.exe in release assets)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to improve Windows backend artifact handling and add stricter validation for missing files during the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->