### PR TITLE
fix: resolve FORCE_JAVASCRIPT_ACTIONS_TO_NODE24

### DIFF
--- a/.github/workflows/agent-dispatcher.yml
+++ b/.github/workflows/agent-dispatcher.yml
@@ -22,7 +22,6 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
       GH_REPO: ${{ github.repository }}
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     
     steps:
       - name: Analyze Issue

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -20,10 +20,10 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -46,7 +46,7 @@ jobs:
       - name: Post PR Comment
         if: github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const fs = require('fs');
@@ -55,5 +55,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "### 📊 Benchmark Summary\n" + summary
+              body: "### ðŸ“Š Benchmark Summary\n" + summary
             })

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -8,9 +8,6 @@ concurrency:
   group: benchmarks-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   contents: read
   issues: write
@@ -20,10 +17,10 @@ jobs:
   benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
@@ -46,7 +43,7 @@ jobs:
       - name: Post PR Comment
         if: github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
-        uses: actions/github-script@v8
+        uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
@@ -55,5 +52,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: "### ðŸ“Š Benchmark Summary\n" + summary
+              body: "### 📊 Benchmark Summary\n" + summary
             })

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -64,7 +64,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install cargo-audit
         run: cargo install cargo-audit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   contents: read
   security-events: write
@@ -22,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -64,7 +61,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Install cargo-audit
         run: cargo install cargo-audit

--- a/.github/workflows/guardian-agent.yml
+++ b/.github/workflows/guardian-agent.yml
@@ -26,7 +26,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get PR Info
         id: pr-info
@@ -84,12 +84,12 @@ jobs:
           # Auto-merge conditions (70% confidence threshold)
           if [ "$CI" = "true" ] && [ "$CONF" -ge 70 ]; then
             echo "decision=auto-merge" >> $GITHUB_OUTPUT
-            echo "🤖 Guardian: CONFIDENCE $CONF% - AUTO-MERGE ENABLED"
+            echo "ðŸ¤– Guardian: CONFIDENCE $CONF% - AUTO-MERGE ENABLED"
             
             # In production: gh pr merge $PR --auto --delete-branch
           else
             echo "decision=review-required" >> $GITHUB_OUTPUT
-            echo "🤖 Guardian: CONFIDENCE $CONF% - MANUAL REVIEW REQUIRED"
+            echo "ðŸ¤– Guardian: CONFIDENCE $CONF% - MANUAL REVIEW REQUIRED"
           fi
 
       - name: Post Decision
@@ -98,9 +98,9 @@ jobs:
           DECISION=${{ steps.decision.outputs.decision }}
           
           if [ "$DECISION" = "auto-merge" ]; then
-            BODY="🤖 **Guardian Decision**: AUTO-MERGE (Confidence: ${{ steps.confidence.outputs.confidence }}%)"
+            BODY="ðŸ¤– **Guardian Decision**: AUTO-MERGE (Confidence: ${{ steps.confidence.outputs.confidence }}%)"
             gh pr comment $PR --body "$BODY"
           else
-            BODY="🤖 **Guardian Decision**: Manual review required. CI must pass and confidence must be ≥70%."
+            BODY="ðŸ¤– **Guardian Decision**: Manual review required. CI must pass and confidence must be â‰¥70%."
             gh pr comment $PR --body "$BODY"
           fi

--- a/.github/workflows/guardian-agent.yml
+++ b/.github/workflows/guardian-agent.yml
@@ -22,11 +22,10 @@ jobs:
       checks: read
     env:
       GH_TOKEN: ${{ github.token }}
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Get PR Info
         id: pr-info
@@ -84,12 +83,12 @@ jobs:
           # Auto-merge conditions (70% confidence threshold)
           if [ "$CI" = "true" ] && [ "$CONF" -ge 70 ]; then
             echo "decision=auto-merge" >> $GITHUB_OUTPUT
-            echo "ðŸ¤– Guardian: CONFIDENCE $CONF% - AUTO-MERGE ENABLED"
+            echo "🤖 Guardian: CONFIDENCE $CONF% - AUTO-MERGE ENABLED"
             
             # In production: gh pr merge $PR --auto --delete-branch
           else
             echo "decision=review-required" >> $GITHUB_OUTPUT
-            echo "ðŸ¤– Guardian: CONFIDENCE $CONF% - MANUAL REVIEW REQUIRED"
+            echo "🤖 Guardian: CONFIDENCE $CONF% - MANUAL REVIEW REQUIRED"
           fi
 
       - name: Post Decision
@@ -98,9 +97,9 @@ jobs:
           DECISION=${{ steps.decision.outputs.decision }}
           
           if [ "$DECISION" = "auto-merge" ]; then
-            BODY="ðŸ¤– **Guardian Decision**: AUTO-MERGE (Confidence: ${{ steps.confidence.outputs.confidence }}%)"
+            BODY="🤖 **Guardian Decision**: AUTO-MERGE (Confidence: ${{ steps.confidence.outputs.confidence }}%)"
             gh pr comment $PR --body "$BODY"
           else
-            BODY="ðŸ¤– **Guardian Decision**: Manual review required. CI must pass and confidence must be â‰¥70%."
+            BODY="🤖 **Guardian Decision**: Manual review required. CI must pass and confidence must be ≥70%."
             gh pr comment $PR --body "$BODY"
           fi

--- a/.github/workflows/jules-auto-merge.yml
+++ b/.github/workflows/jules-auto-merge.yml
@@ -18,10 +18,10 @@ jobs:
     if: contains(github.event.pull_request.body, 'PR created automatically by Jules') || contains(github.event.pull_request.labels.*.name, 'jules')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 

--- a/.github/workflows/jules-auto-merge.yml
+++ b/.github/workflows/jules-auto-merge.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches: [ "main" ]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   contents: write
   pull-requests: write
@@ -18,10 +15,10 @@ jobs:
     if: contains(github.event.pull_request.body, 'PR created automatically by Jules') || contains(github.event.pull_request.labels.*.name, 'jules')
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 

--- a/.github/workflows/planner-agent.yml
+++ b/.github/workflows/planner-agent.yml
@@ -24,7 +24,7 @@ jobs:
       FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           sparse-checkout: |
             .gitcore/ARCHITECTURE.md

--- a/.github/workflows/planner-agent.yml
+++ b/.github/workflows/planner-agent.yml
@@ -20,11 +20,9 @@ jobs:
     permissions:
       contents: read
       issues: write
-    env:
-      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-    
+
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
         with:
           sparse-checkout: |
             .gitcore/ARCHITECTURE.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -55,7 +55,7 @@ jobs:
     runs-on: windows-latest
     needs: [quality-gate]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -69,7 +69,7 @@ jobs:
         run: cargo build --release -p gestalt_timeline
 
       - name: Upload Backend Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: neural-link-backend-windows
           path: target/release/gestalt.exe
@@ -93,7 +93,7 @@ jobs:
             artifact_name: gestalt-cli-macos
             binary_path: target/release/gestalt_cli
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Rust Cache
@@ -101,7 +101,7 @@ jobs:
       - name: Build CLI
         run: cargo build --release -p gestalt_cli
       - name: Upload CLI Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.binary_path }}
@@ -114,10 +114,10 @@ jobs:
       run:
         working-directory: ./gestalt_app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -135,7 +135,7 @@ jobs:
         run: flutter build apk --release
 
       - name: Upload Mobile Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: neural-link-app-android
           path: gestalt_app/build/app/outputs/flutter-apk/app-release.apk
@@ -146,18 +146,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Backend Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: neural-link-backend-windows
           path: release-assets
 
       - name: Download CLI Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: release-assets/cli-artifacts
 
       - name: Download Mobile Artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: neural-link-app-android
           path: release-assets
@@ -181,7 +181,7 @@ jobs:
           cp release-assets/cli-artifacts/gestalt-cli-macos/gestalt_cli release-assets/gestalt-cli-macos
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.release_tag }}
           name: Gestalt ${{ steps.tag.outputs.release_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,9 +9,6 @@ concurrency:
   group: release-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 permissions:
   contents: write
 
@@ -21,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -55,7 +52,7 @@ jobs:
     runs-on: windows-latest
     needs: [quality-gate]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -69,7 +66,7 @@ jobs:
         run: cargo build --release -p gestalt_timeline
 
       - name: Upload Backend Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: neural-link-backend-windows
           path: target/release/gestalt.exe
@@ -93,7 +90,7 @@ jobs:
             artifact_name: gestalt-cli-macos
             binary_path: target/release/gestalt_cli
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Rust Cache
@@ -101,7 +98,7 @@ jobs:
       - name: Build CLI
         run: cargo build --release -p gestalt_cli
       - name: Upload CLI Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.binary_path }}
@@ -114,10 +111,10 @@ jobs:
       run:
         working-directory: ./gestalt_app
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v4
 
       - name: Setup Java
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -135,7 +132,7 @@ jobs:
         run: flutter build apk --release
 
       - name: Upload Mobile Artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: neural-link-app-android
           path: gestalt_app/build/app/outputs/flutter-apk/app-release.apk
@@ -146,18 +143,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download Backend Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: neural-link-backend-windows
           path: release-assets
 
       - name: Download CLI Artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           path: release-assets/cli-artifacts
 
       - name: Download Mobile Artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@v4
         with:
           name: neural-link-app-android
           path: release-assets
@@ -181,7 +178,7 @@ jobs:
           cp release-assets/cli-artifacts/gestalt-cli-macos/gestalt_cli release-assets/gestalt-cli-macos
 
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ steps.tag.outputs.release_tag }}
           name: Gestalt ${{ steps.tag.outputs.release_tag }}


### PR DESCRIPTION
## Summary
- remove `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24` from all affected GitHub Actions workflows
- keep the existing workflow behavior otherwise unchanged
- cover CI, release, benchmarks, dispatcher, guardian, planner, and Jules auto-merge workflows

## Verification
- `cargo build --all-targets` ✅
- `cargo test --all-targets` ❌ existing failure in `gestalt_timeline/tests/e2e_runtime.rs:test_tools_execute_shell_and_read_file`
  - observed assertion: expected `write_result["success"] == true`, got `null`
  - this failure is unrelated to the workflow env-var removal


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration across multiple build pipelines to ensure consistent behavior in automated testing and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->