### PR TITLE
fix(ci): correct release artifact path for backend binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Prepare CLI Binaries
         run: |
-          cp release-assets/neural-link-backend-windows/gestalt.exe release-assets/gestalt_timeline.exe
+          cp release-assets/gestalt.exe release-assets/gestalt_timeline.exe
           cp release-assets/neural-link-app-android/app-release.apk release-assets/app-release.apk
           cp release-assets/cli-artifacts/gestalt-cli-windows/gestalt_cli.exe release-assets/gestalt-cli-windows.exe
           cp release-assets/cli-artifacts/gestalt-cli-linux/gestalt_cli release-assets/gestalt-cli-linux


### PR DESCRIPTION
## Auto-Fix PR

Fixes: Build and Release #89, #90 - cp: cannot stat 'release-assets/neural-link-backend-windows/gestalt.exe'

### Root Cause
The create-release job downloads the backend artifact to release-assets/gestalt.exe directly, but the Prepare CLI Binaries step was referencing release-assets/neural-link-backend-windows/gestalt.exe (wrong path).

### Fix
Updated the cp command to use the correct path: release-assets/gestalt.exe instead of release-assets/neural-link-backend-windows/gestalt.exe.

### Verification
- [x] Syntax check (workflow YAML valid)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release build process for Windows binaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->