### PR TITLE
fix(ci): correct release artifact path for backend binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Prepare CLI Binaries
         run: |
-          cp release-assets/neural-link-backend-windows/gestalt.exe release-assets/gestalt_timeline.exe
+          cp release-assets/gestalt.exe release-assets/gestalt_timeline.exe
           cp release-assets/neural-link-app-android/app-release.apk release-assets/app-release.apk
           cp release-assets/cli-artifacts/gestalt-cli-windows/gestalt_cli.exe release-assets/gestalt-cli-windows.exe
           cp release-assets/cli-artifacts/gestalt-cli-linux/gestalt_cli release-assets/gestalt-cli-linux


### PR DESCRIPTION
## CI Fix: Release Artifact Path

### Root Cause
The Build and Release workflow has been failing because the backend artifact download path didn't match the expected location in the Prepare CLI Binaries step.

After commit \84e093\ (corrected backend binary name from \gestalt_timeline\ to \gestalt\), the upload artifact path was updated but the download/copy step was not.

### Changes
- Backend copy path: \elease-assets/neural-link-backend-windows/gestalt.exe\ → \elease-assets/gestalt.exe\

### Testing
CI will validate the artifact path fix.

### Related
- Closes #184 (Build and Release fails: Prepare CLI Binaries step)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal release build process for Windows binary handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->