### PR TITLE
fix(ci): consolidate artifact downloads and fix APK path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,21 +145,9 @@ jobs:
     needs: [quality-gate, build-backend, build-cli, build-mobile]
     runs-on: ubuntu-latest
     steps:
-      - name: Download Backend Artifact
+      - name: Download All Artifacts
         uses: actions/download-artifact@v4
         with:
-          name: neural-link-backend-windows
-          path: release-assets
-
-      - name: Download CLI Artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: release-assets/cli-artifacts
-
-      - name: Download Mobile Artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: neural-link-app-android
           path: release-assets
 
       - name: Generate Release Tag
@@ -174,11 +162,11 @@ jobs:
 
       - name: Prepare CLI Binaries
         run: |
-          cp release-assets/gestalt.exe release-assets/gestalt_timeline.exe
+          cp release-assets/neural-link-backend-windows/gestalt.exe release-assets/gestalt_timeline.exe
           cp release-assets/neural-link-app-android/app-release.apk release-assets/app-release.apk
-          cp release-assets/cli-artifacts/gestalt-cli-windows/gestalt_cli.exe release-assets/gestalt-cli-windows.exe
-          cp release-assets/cli-artifacts/gestalt-cli-linux/gestalt_cli release-assets/gestalt-cli-linux
-          cp release-assets/cli-artifacts/gestalt-cli-macos/gestalt_cli release-assets/gestalt-cli-macos
+          cp release-assets/gestalt-cli-windows/gestalt_cli.exe release-assets/gestalt-cli-windows.exe
+          cp release-assets/gestalt-cli-linux/gestalt_cli release-assets/gestalt-cli-linux
+          cp release-assets/gestalt-cli-macos/gestalt_cli release-assets/gestalt-cli-macos
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
The Build and Release workflow was failing at the 'Prepare CLI Binaries' step because the APK artifact was being downloaded to the wrong subdirectory path.

### Root Cause
Multiple sequential actions/download-artifact@v4 steps were causing path conflicts.

### Fix
- Consolidated all artifact downloads into a single step
- Updated cp paths to use named subdirectories (neural-link-backend-windows/, gestalt-cli-windows/, etc.)

Fixes Build and Release #92, #91, #90, #89

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized release artifact handling in CI/CD workflows for improved build efficiency.

---

**Note:** This release contains no user-facing changes. Updates are internal to the build and release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->