### PR TITLE
fix(ci): remove redundant mkdir/cp for CLI artifacts in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,10 +162,8 @@ jobs:
           cp release-assets/neural-link-backend-windows/gestalt.exe release-assets/gestalt_timeline.exe
           cp release-assets/neural-link-app-android/app-release.apk release-assets/app-release.apk
           cp release-assets/gestalt-cli-windows/gestalt_cli.exe release-assets/gestalt-cli-windows.exe
-          mkdir -p release-assets/gestalt-cli-linux
-          cp release-assets/gestalt-cli-linux/gestalt_cli release-assets/gestalt-cli-linux/gestalt_cli
-          mkdir -p release-assets/gestalt-cli-macos
-          cp release-assets/gestalt-cli-macos/gestalt_cli release-assets/gestalt-cli-macos/gestalt_cli
+          # gestalt-cli-linux and gestalt-cli-macos artifacts are downloaded as single files
+          # (not directories), already at the correct release-assets path
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary

Fixes the Build and Release workflow failure:

`
cp: 'release-assets/gestalt-cli-linux/gestalt_cli' and 'release-assets/gestalt-cli-linux/gestalt_cli' are the same file
`

## Root Cause

In the Prepare CLI Binaries step, mkdir -p release-assets/gestalt-cli-linux creates a directory at the same path where ctions/download-artifact@v4 has already placed the artifact file (elease-assets/gestalt-cli-linux/gestalt_cli). The subsequent cp command then tries to copy the file to itself.

## Fix

Remove the redundant mkdir -p and cp commands for Linux and macOS CLI artifacts, since download-artifact@v4 already places them at the correct elease-assets/ paths.

## Testing

The fix can only be verified by running the Build and Release workflow on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized the release build workflow for improved efficiency.

---

**Note:** This release contains no user-facing changes or features. All modifications are internal infrastructure improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->