### PR TITLE
fix: remove self-copy steps in Prepare CLI Binaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,10 +162,6 @@ jobs:
           cp release-assets/neural-link-backend-windows/gestalt.exe release-assets/gestalt_timeline.exe
           cp release-assets/neural-link-app-android/app-release.apk release-assets/app-release.apk
           cp release-assets/gestalt-cli-windows/gestalt_cli.exe release-assets/gestalt-cli-windows.exe
-          mkdir -p release-assets/gestalt-cli-linux
-          cp release-assets/gestalt-cli-linux/gestalt_cli release-assets/gestalt-cli-linux/gestalt_cli
-          mkdir -p release-assets/gestalt-cli-macos
-          cp release-assets/gestalt-cli-macos/gestalt_cli release-assets/gestalt-cli-macos/gestalt_cli
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary

Remove redundant mkdir+cp steps for gestalt-cli-linux and gestalt-cli-macos in the Prepare CLI Binaries step of .github/workflows/release.yml.

## Root Cause

ctions/download-artifact@v4 extracts artifacts preserving their structure. The Linux artifact named gestalt-cli-linux containing 	arget/release/gestalt_cli is extracted to:

`
release-assets/gestalt-cli-linux/gestalt_cli
`

The workflow then ran:
`ash
mkdir -p release-assets/gestalt-cli-linux
cp release-assets/gestalt-cli-linux/gestalt_cli release-assets/gestalt-cli-linux/gestalt_cli
`

This copies the file to itself, causing:
`
cp: 'release-assets/gestalt-cli-linux/gestalt_cli' and
    'release-assets/gestalt-cli-linux/gestalt_cli' are the same file
`

## Fix

Remove the redundant mkdir+cp steps for both Linux and macOS artifacts since download-artifact already places them in the correct location.

## Testing

CI must pass on this PR before merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed staging steps for Linux and macOS CLI binaries from the automated release workflow. CLI binaries will no longer be prepared in the release-assets directories, though the packaging configuration still references these locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->