### PR TITLE
fix(ci): flatten CLI artifacts to resolve missing binary paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.binary_path }}
+          flatten: true
 
   build-mobile:
     name: Build Mobile (Android)
@@ -163,9 +164,9 @@ jobs:
           cp release-assets/neural-link-app-android/app-release.apk release-assets/app-release.apk
           cp release-assets/gestalt-cli-windows/gestalt_cli.exe release-assets/gestalt-cli-windows.exe
           mkdir -p release-assets/gestalt-cli-linux
-          cp release-assets/gestalt-cli-linux/target/release/gestalt_cli release-assets/gestalt-cli-linux/gestalt_cli
+          cp release-assets/gestalt-cli-linux/gestalt_cli release-assets/gestalt-cli-linux/gestalt_cli
           mkdir -p release-assets/gestalt-cli-macos
-          cp release-assets/gestalt-cli-macos/target/release/gestalt_cli release-assets/gestalt-cli-macos/gestalt_cli
+          cp release-assets/gestalt-cli-macos/gestalt_cli release-assets/gestalt-cli-macos/gestalt_cli
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary

Fix CI failure in Build and Release workflow where Linux/macOS CLI binaries were not found during the release creation step.

### Root Cause

The uild-cli job uploads artifacts using ctions/upload-artifact@v4 with the full path 	arget/release/gestalt_cli. This preserves the directory structure in the artifact. When the create-release job downloads artifacts and copies them with:

\\\ash
cp release-assets/gestalt-cli-linux/target/release/gestalt_cli release-assets/gestalt-cli-linux/gestalt_cli
\\\

This path did not match the actual artifact contents, causing \cp: cannot stat\ errors.

### Fix

1. Added \latten: true\ to the CLI artifact upload step — this stores only the binary filename in the artifact, stripping the \	arget/release/\ prefix.
2. Updated the \cp\ commands in the release job to use the correct flat paths.

### Files Changed

- \.github/workflows/release.yml\

### Testing

The fix will be validated by the CI running on this PR. Once merged, the next release build should complete successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release build artifact handling and binary retrieval in the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->