### PR TITLE
fix(ci): correct APK artifact path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
       - name: Prepare CLI Binaries
         run: |
           cp release-assets/neural-link-backend-windows/gestalt.exe release-assets/gestalt_timeline.exe
-          cp release-assets/neural-link-app-android/app-release.apk release-assets/app-release.apk
+          cp release-assets/neural-link-app-android/gestalt_app/build/app/outputs/flutter-apk/app-release.apk release-assets/app-release.apk
           cp release-assets/gestalt-cli-windows/gestalt_cli.exe release-assets/gestalt-cli-windows.exe
           mkdir -p release-assets/gestalt-cli-linux
           cp release-assets/gestalt-cli-linux/target/release/gestalt_cli release-assets/gestalt-cli-linux/gestalt_cli


### PR DESCRIPTION
## Summary

The 'Prepare CLI Binaries' step in the release workflow was failing because it referenced the wrong path for the Android APK artifact.

The APK artifact contains the file at:
\
eural-link-app-android/gestalt_app/build/app/outputs/flutter-apk/app-release.apk\

But the step was looking for it at:
\elease-assets/neural-link-app-android/app-release.apk\ (incorrect)

Fixed by updating the cp command to reference the correct nested path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Android app release packaging by correcting the artifact file path in the release workflow to ensure proper app distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->