### PR TITLE
fix(ci): add FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 to all workflows

### DIFF
--- a/.github/workflows/agent-dispatcher.yml
+++ b/.github/workflows/agent-dispatcher.yml
@@ -13,6 +13,9 @@ on:
         required: false
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,6 +13,9 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   rust-checks:
     name: Rust Checks

--- a/.github/workflows/guardian-agent.yml
+++ b/.github/workflows/guardian-agent.yml
@@ -13,6 +13,9 @@ on:
         required: false
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   guardian:
     runs-on: ubuntu-latest

--- a/.github/workflows/jules-auto-merge.yml
+++ b/.github/workflows/jules-auto-merge.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   wait-for-jules:
     name: Wait for entire Jules Team

--- a/.github/workflows/planner-agent.yml
+++ b/.github/workflows/planner-agent.yml
@@ -14,6 +14,9 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Mondays at 6 AM UTC
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   plan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolves Node 20 deprecated warnings in GitHub Actions across all workflows. Previously only release.yml had this env var set.

Fixes: Build and Release #97, #101, #102 (and likely others)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal GitHub Actions workflows to use Node 24 for JavaScript actions across all automated build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->