### PR TITLE
fix(ci): resolve cp same-file error in Create Release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -162,13 +162,19 @@ jobs:
 
       - name: Prepare CLI Binaries
         run: |
-          cp release-assets/neural-link-backend-windows/gestalt.exe release-assets/gestalt_timeline.exe
-          cp release-assets/neural-link-app-android/app-release.apk release-assets/app-release.apk
-          cp release-assets/gestalt-cli-windows/gestalt_cli.exe release-assets/gestalt-cli-windows.exe
-          mkdir -p release-assets/gestalt-cli-linux
-          cp release-assets/gestalt-cli-linux/gestalt_cli release-assets/gestalt-cli-linux/gestalt_cli
-          mkdir -p release-assets/gestalt-cli-macos
-          cp release-assets/gestalt-cli-macos/gestalt_cli release-assets/gestalt-cli-macos/gestalt_cli
+          # Rename backend and mobile artifacts
+          mv release-assets/neural-link-backend-windows/gestalt.exe release-assets/gestalt_timeline.exe
+          mv release-assets/neural-link-app-android/app-release.apk release-assets/app-release.apk
+          # Rename CLI Windows artifact
+          mv release-assets/gestalt-cli-windows/gestalt_cli.exe release-assets/gestalt-cli-windows.exe
+          # Package Linux binary as tar.gz (binary is already in gestalt-cli-linux/)
+          mv release-assets/gestalt-cli-linux/gestalt_cli release-assets/gestalt-cli-linux/gestalt
+          tar -czf release-assets/gestalt-cli-linux.tar.gz -C release-assets gestalt-cli-linux
+          # Package macOS binary as tar.gz
+          mv release-assets/gestalt-cli-macos/gestalt_cli release-assets/gestalt-cli-macos/gestalt
+          tar -czf release-assets/gestalt-cli-macos.tar.gz -C release-assets gestalt-cli-macos
+        env:
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
@@ -181,7 +187,7 @@ jobs:
             release-assets/gestalt_timeline.exe
             release-assets/app-release.apk
             release-assets/gestalt-cli-windows.exe
-            release-assets/gestalt-cli-linux
-            release-assets/gestalt-cli-macos
+            release-assets/gestalt-cli-linux.tar.gz
+            release-assets/gestalt-cli-macos.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes CI failure: cp: file and file are the same file in the Create Release job.

## Root Cause

ctions/download-artifact@v4 downloads artifacts into subdirectories named after the artifact. The Prepare CLI Binaries step was:
1. Creating subdirectories with the same names (which already exist from download)
2. Copying binary files to themselves (same path after mkdir)

`ash
mkdir -p release-assets/gestalt-cli-linux
cp release-assets/gestalt-cli-linux/gestalt_cli release-assets/gestalt-cli-linux/gestalt_cli
#                            same path ────────────────────────────────────── same path
`

## Fix

- Replace cp with mv for backend/mobile artifacts (no self-copy issue)
- Package Linux/macOS binaries as .tar.gz archives for release upload
- Added FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true env to suppress Node 20 deprecation warnings

## Testing

- cargo build --all-targets: ✅ Passed
- cargo test --all-targets: Will be verified by CI

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release artifact packaging for improved distribution. Linux and macOS command-line tools are now delivered as compressed archives. Backend and mobile app artifacts have been reorganized for better release consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->