### PR TITLE
fix(ci): remove redundant cp commands in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,10 +165,6 @@ jobs:
           cp release-assets/neural-link-backend-windows/gestalt.exe release-assets/gestalt_timeline.exe
           cp release-assets/neural-link-app-android/app-release.apk release-assets/app-release.apk
           cp release-assets/gestalt-cli-windows/gestalt_cli.exe release-assets/gestalt-cli-windows.exe
-          mkdir -p release-assets/gestalt-cli-linux
-          cp release-assets/gestalt-cli-linux/gestalt_cli release-assets/gestalt-cli-linux/gestalt_cli
-          mkdir -p release-assets/gestalt-cli-macos
-          cp release-assets/gestalt-cli-macos/gestalt_cli release-assets/gestalt-cli-macos/gestalt_cli
 
       - name: Create Release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Auto-Fix PR

Fixes Build and Release failures (runs #102, #101, #97, #96, #95).

### Root Cause
The \Prepare CLI Binaries\ step had redundant \mkdir -p\ + \cp\ commands for \gestalt-cli-linux\ and \gestalt-cli-macos\. After \download-artifact@v4\, the files were already in place at \elease-assets/gestalt-cli-linux/gestalt_cli\. The \cp\ then tried to copy the file onto itself, causing:
\\\
cp: 'release-assets/gestalt-cli-linux/gestalt_cli' and 'release-assets/gestalt-cli-linux/gestalt_cli' are the same file
\\\

### Fix
Remove the redundant mkdir/cp steps for CLI binaries. The download-artifact@v4 already preserves the artifact structure correctly.

### Verification
- \cargo check --all-targets\ ✅ passes
- \cargo build --all-targets\ ✅ passes

- [ ] CI passes
- [ ] Ready to merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified release workflow by removing automated packaging steps for Linux and macOS binary distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->