### PR TITLE
fix(ci): propagate FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 to all workflows

### DIFF
--- a/.github/workflows/agent-dispatcher.yml
+++ b/.github/workflows/agent-dispatcher.yml
@@ -13,6 +13,9 @@ on:
         required: false
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,6 +13,9 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   benchmark:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ permissions:
   contents: read
   security-events: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   rust-checks:
     name: Rust Checks

--- a/.github/workflows/guardian-agent.yml
+++ b/.github/workflows/guardian-agent.yml
@@ -13,6 +13,9 @@ on:
         required: false
         type: string
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   guardian:
     runs-on: ubuntu-latest

--- a/.github/workflows/jules-auto-merge.yml
+++ b/.github/workflows/jules-auto-merge.yml
@@ -8,6 +8,9 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   wait-for-jules:
     name: Wait for entire Jules Team

--- a/.github/workflows/planner-agent.yml
+++ b/.github/workflows/planner-agent.yml
@@ -14,6 +14,9 @@ on:
   schedule:
     - cron: '0 6 * * 1'  # Mondays at 6 AM UTC
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   plan:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Propagates the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true env var (already present in elease.yml) to all 6 remaining workflows:
- gent-dispatcher.yml
- enchmarks.yml
- ci.yml
- guardian-agent.yml
- jules-auto-merge.yml
- planner-agent.yml

## Root Cause
ctions/upload-artifact@v4 and ctions/download-artifact@v4 emit deprecation warnings when running on Node 20. The override was only set in elease.yml, causing CI failures across all workflows.

## Testing
- ✅ Workflow files updated
- ⚠️ Full cargo build --all-targets && cargo test --all-targets skipped (build takes >5 min in this environment); verified the change is purely workflow-level YAML

Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows to execute JavaScript actions with Node.js 24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->