### PR TITLE
fix(ci): update GitHub Actions to Node24-compatible versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,16 +12,13 @@ concurrency:
 permissions:
   contents: write
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   quality-gate:
     name: Quality Gate
     runs-on: ubuntu-latest
     timeout-minutes: 180
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -55,7 +52,7 @@ jobs:
     runs-on: windows-latest
     needs: [quality-gate]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -69,7 +66,7 @@ jobs:
         run: cargo build --release -p gestalt_timeline
 
       - name: Upload Backend Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: neural-link-backend-windows
           path: target/release/gestalt.exe
@@ -93,7 +90,7 @@ jobs:
             artifact_name: gestalt-cli-macos
             binary_path: target/release/gestalt_cli
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Rust Cache
@@ -101,7 +98,7 @@ jobs:
       - name: Build CLI
         run: cargo build --release -p gestalt_cli
       - name: Upload CLI Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: ${{ matrix.artifact_name }}
           path: ${{ matrix.binary_path }}
@@ -114,10 +111,10 @@ jobs:
       run:
         working-directory: ./gestalt_app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: 'zulu'
           java-version: '17'
@@ -135,7 +132,7 @@ jobs:
         run: flutter build apk --release
 
       - name: Upload Mobile Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: neural-link-app-android
           path: gestalt_app/build/app/outputs/flutter-apk/app-release.apk
@@ -146,7 +143,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download All Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           path: release-assets
 
@@ -171,7 +168,7 @@ jobs:
           cp release-assets/gestalt-cli-macos/gestalt_cli release-assets/gestalt-cli-macos/gestalt_cli
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.release_tag }}
           name: Gestalt ${{ steps.tag.outputs.release_tag }}


### PR DESCRIPTION
## Summary
Updates GitHub Actions to Node 24-compatible versions to resolve the Node.js 20 deprecation in the Build and Release workflow.

## Changes
- Remove FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 workaround
- Update actions/checkout v4 -> v6
- Update actions/upload-artifact v4 -> v6
- Update actions/download-artifact v4 -> v5
- Update actions/setup-java v4 -> v5
- Update softprops/action-gh-release v1 -> v2

## Testing
CI build + test on the PR will validate the changes.

Closes #102, #101, #97, #100, #99 (Build and Release failures)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions versions in the release workflow to the latest releases for checkout, artifact management, Java setup, and release tools. Removed an obsolete configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->