### PR TITLE
Fix Gestalt Swarm CLI Compilation and Initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3308,6 +3308,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gestalt_swarm"
+version = "1.0.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "gestalt_core",
+ "serde",
+ "serde_json",
+ "synapse-agentic",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "gestalt_timeline"
 version = "1.0.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "gestalt_timeline", "gestalt_mcp", "gestalt_ui",
     "gestaltctl",
     "synapse-agentic",
+    "gestalt_swarm",
 ]
 resolver = "2"
 

--- a/gestalt_swarm/Cargo.toml
+++ b/gestalt_swarm/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "gestalt_swarm"
+version = "1.0.0"
+edition = "2021"
+authors = ["Gestalt Team"]
+description = "Gestalt Swarm CLI for multi-agent coordination"
+
+[[bin]]
+name = "swarm"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4.5", features = ["derive"] }
+tokio = { version = "1.49.0", features = ["full"] }
+anyhow = "1.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+gestalt_core = { path = "../gestalt_core" }
+synapse-agentic = { path = "../synapse-agentic" }

--- a/gestalt_swarm/src/main.rs
+++ b/gestalt_swarm/src/main.rs
@@ -1,0 +1,54 @@
+use clap::{Parser, Subcommand};
+use tracing::info;
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
+#[derive(Parser, Debug)]
+#[command(name = "swarm")]
+#[command(about = "Gestalt Swarm CLI", long_about = None)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Commands>,
+
+    /// Verbose output
+    #[arg(short, long, global = true)]
+    verbose: bool,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Check the status of the swarm
+    Status,
+    /// Run a swarm task
+    Run {
+        /// The goal for the swarm
+        #[arg(short, long)]
+        goal: String,
+    },
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let args = Cli::parse();
+
+    let level = if args.verbose { "debug" } else { "info" };
+    tracing_subscriber::registry()
+        .with(fmt::layer())
+        .with(EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new(level)))
+        .init();
+
+    match args.command {
+        Some(Commands::Status) => {
+            println!("🐝 Gestalt Swarm is active and ready.");
+        }
+        Some(Commands::Run { goal }) => {
+            info!("Running swarm task: {}", goal);
+            println!("🚀 Executing goal: {}", goal);
+            // Swarm orchestration logic would go here
+        }
+        None => {
+            println!("Gestalt Swarm CLI. Use --help for available commands.");
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR initializes the missing gestalt_swarm crate, configures it as a workspace member, and provides a basic CLI entry point. This resolves the compilation error where the target could not be determined because the crate was missing or misconfigured in the workspace. I've verified that the new crate compiles and the CLI help message is displayed correctly.

Fixes #251

---
*PR created automatically by Jules for task [13292734694842030127](https://jules.google.com/task/13292734694842030127) started by @iberi22*