### PR TITLE
Add integration tests for Swarm CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
       - name: Cargo Test (CLI)
         run: cargo test -p gestalt_cli --all-targets
 
+      - name: Cargo Test (Swarm)
+        run: cargo test -p gestalt_swarm --all-targets
+
       - name: Cargo Test (Timeline)
         run: cargo test -p gestalt_timeline --lib
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert_cmd"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a686bbee5efb88a82df0621b236e74d925f470e5445d3220a5648b892ec99c9"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1982,6 +1997,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "abd57806937c9cc163efc8ea3910e00a62e2aeb0b8119f1793a978088f8f6b04"
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2612,6 +2633,15 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float-cmp"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -3275,8 +3305,10 @@ name = "gestalt_swarm"
 version = "1.0.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "clap",
  "gestalt_core",
+ "predicates",
  "serde",
  "serde_json",
  "synapse-agentic",
@@ -5095,6 +5127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "normalize-line-endings"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61807f77802ff30975e01f4f071c8ba10c022052f98b3294119f3e615d13e5be"
+
+[[package]]
 name = "ntapi"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6149,6 +6187,36 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "float-cmp",
+ "normalize-line-endings",
+ "predicates-core",
+ "regex",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
 
 [[package]]
 name = "presser"
@@ -8387,6 +8455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9236,6 +9310,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/gestalt_swarm/Cargo.toml
+++ b/gestalt_swarm/Cargo.toml
@@ -19,3 +19,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 gestalt_core = { path = "../gestalt_core" }
 synapse-agentic = { path = "../synapse-agentic" }
+
+[dev-dependencies]
+assert_cmd = "2.0"
+predicates = "3.1"

--- a/gestalt_swarm/tests/swarm_cli_test.rs
+++ b/gestalt_swarm/tests/swarm_cli_test.rs
@@ -1,0 +1,38 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+
+#[test]
+fn test_swarm_help() {
+    let mut cmd = Command::cargo_bin("swarm").unwrap();
+    cmd.arg("--help");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Gestalt Swarm CLI"));
+}
+
+#[test]
+fn test_swarm_status() {
+    let mut cmd = Command::cargo_bin("swarm").unwrap();
+    cmd.arg("status");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Gestalt Swarm is active and ready."));
+}
+
+#[test]
+fn test_swarm_run() {
+    let mut cmd = Command::cargo_bin("swarm").unwrap();
+    cmd.arg("run").arg("--goal").arg("test_goal");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Executing goal: test_goal"));
+}
+
+#[test]
+fn test_swarm_verbose() {
+    let mut cmd = Command::cargo_bin("swarm").unwrap();
+    cmd.arg("--verbose").arg("status");
+    cmd.assert()
+        .success()
+        .stdout(predicate::str::contains("Gestalt Swarm is active and ready."));
+}


### PR DESCRIPTION
This PR adds integration tests for the `gestalt_swarm` CLI to verify core functionality as requested. 

The tests cover:
- `swarm --help`: Verifies help output.
- `swarm status`: Verifies successful status check.
- `swarm run --goal "..."`: Verifies task execution without panic.
- `--verbose` flag: Verifies that the verbose flag works with commands.

The tests use the `assert_cmd` crate for robust CLI testing and have been integrated into the CI workflow.

Fixes #258

---
*PR created automatically by Jules for task [1285935396252192570](https://jules.google.com/task/1285935396252192570) started by @iberi22*