### PR TITLE
Fix ToolRegistry mock implementation causing test failures

### DIFF
--- a/synapse-agentic/src/lib.rs
+++ b/synapse-agentic/src/lib.rs
@@ -387,11 +387,20 @@ pub mod prelude {
 
     #[derive(Debug, Clone, Serialize, Deserialize)]
     pub struct EmptyContext;
-    pub trait ToolContext {}
+    pub trait ToolContext: Send + Sync {}
     impl ToolContext for EmptyContext {}
 
-    #[derive(Debug, Clone)]
-    pub struct ToolRegistry;
+    #[derive(Clone)]
+    pub struct ToolRegistry {
+        tools: Arc<tokio::sync::RwLock<std::collections::HashMap<String, Arc<dyn Tool>>>>,
+    }
+
+    impl std::fmt::Debug for ToolRegistry {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            f.debug_struct("ToolRegistry").finish()
+        }
+    }
+
     impl Default for ToolRegistry {
         fn default() -> Self {
             Self::new()
@@ -399,16 +408,28 @@ pub mod prelude {
     }
     impl ToolRegistry {
         pub fn new() -> Self {
-            Self
+            Self {
+                tools: Arc::new(tokio::sync::RwLock::new(std::collections::HashMap::new())),
+            }
         }
-        pub async fn register_tool<T: Tool + 'static>(&self, _tool: T) {}
+        pub async fn register_tool<T: Tool + 'static>(&self, tool: T) {
+            let mut tools = self.tools.write().await;
+            tools.insert(tool.name().to_string(), Arc::new(tool));
+        }
         pub async fn call(
             &self,
-            _name: &str,
+            name: &str,
             _ctx: &EmptyContext,
-            _args: Value,
+            args: Value,
         ) -> anyhow::Result<Value> {
-            Ok(Value::Null)
+            let tool = {
+                let tools = self.tools.read().await;
+                tools
+                    .get(name)
+                    .cloned()
+                    .ok_or_else(|| anyhow::anyhow!("Tool '{}' not found", name))?
+            };
+            tool.call(&EmptyContext, args).await
         }
     }
 


### PR DESCRIPTION
Implemented a functional `ToolRegistry` in the `synapse-agentic` crate. Previously, it was a stub that always returned `Value::Null`, causing e2e tests in `gestalt_timeline` to fail when verifying tool execution (shell and file I/O). The new implementation uses a thread-safe `HashMap` to store and invoke registered tools. Verified the fix by running the affected e2e tests which now pass successfully.

Fixes #143

---
*PR created automatically by Jules for task [17728954663752927339](https://jules.google.com/task/17728954663752927339) started by @iberi22*