### PR TITLE
Timeline — JSONL event log per run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,6 +1777,7 @@ dependencies = [
 name = "gestalt-router"
 version = "0.1.0"
 dependencies = [
+ "dirs",
  "gestalt_core",
  "serde",
  "serde_json",

--- a/gestalt-router/Cargo.toml
+++ b/gestalt-router/Cargo.toml
@@ -11,3 +11,4 @@ thiserror = "1.0.69"
 uuid = { version = "1.15.1", features = ["v4", "serde"] }
 tracing = "0.1.44"
 gestalt_core = { path = "../gestalt_core" }
+dirs = "5.0.1"

--- a/gestalt-router/src/lib.rs
+++ b/gestalt-router/src/lib.rs
@@ -7,5 +7,5 @@ pub mod run_state;
 // pub mod checkpoint;
 // pub mod overlap;
 // pub mod integrate;
-// pub mod timeline;
+pub mod timeline;
 // pub mod doctor;

--- a/gestalt-router/src/run.rs
+++ b/gestalt-router/src/run.rs
@@ -52,4 +52,7 @@ pub enum RouterError {
 
     #[error("Invalid specification: {0}")]
     InvalidSpec(String),
+
+    #[error("Timeline error: {0}")]
+    TimelineError(String),
 }

--- a/gestalt-router/src/timeline.rs
+++ b/gestalt-router/src/timeline.rs
@@ -1,0 +1,223 @@
+use crate::run_state::AgentState;
+use serde::{Deserialize, Serialize};
+use std::fs::{self, File, OpenOptions};
+use std::io::{BufRead, BufReader, BufWriter, Write};
+use std::path::PathBuf;
+use std::sync::Mutex;
+use uuid::Uuid;
+
+/// Helper function to retrieve the base path for runs.
+///
+/// It checks `$GESTALT_HOME` (and joins with `"runs"`) first,
+/// then falls back to `~/.gestalt/runs/`.
+pub fn get_base_dir() -> PathBuf {
+    if let Some(gestalt_home) = std::env::var_os("GESTALT_HOME") {
+        PathBuf::from(gestalt_home).join("runs")
+    } else if let Some(home) = dirs::home_dir() {
+        home.join(".gestalt").join("runs")
+    } else {
+        PathBuf::from(".gestalt").join("runs")
+    }
+}
+
+/// An event tracked in the timeline of a run.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", content = "payload")]
+pub enum Event {
+    RunStarted,
+    AgentStateChanged {
+        agent_id: String,
+        state: AgentState,
+    },
+    CheckpointCommitted {
+        commit_hash: String,
+    },
+    OverlapDetected {
+        paths: Vec<String>,
+    },
+    MergeComputed {
+        target_branch: String,
+        success: bool,
+    },
+    BranchPublished {
+        branch: String,
+    },
+    SymlinkEscape {
+        path: String,
+    },
+    ExcludedFile {
+        path: String,
+    },
+    RunFinished,
+}
+
+/// A wrapper to include a schema version in each logged event.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VersionedEvent {
+    pub v: usize,
+    #[serde(flatten)]
+    pub event: Event,
+}
+
+/// Trait defining the operations on an append-only timeline log.
+pub trait EventLog {
+    /// Appends an event to the log.
+    fn append(&self, event: Event) -> Result<(), crate::run::RouterError>;
+
+    /// Reads all successfully parsed events for a specific run.
+    fn read_events(&self, run_id: Uuid) -> Result<Vec<Event>, crate::run::RouterError>;
+
+    /// Lists all run IDs that have logs in the directory.
+    fn list_runs(&self) -> Result<Vec<Uuid>, crate::run::RouterError>;
+}
+
+/// A JSON Lines (JSONL) implementation of the EventLog trait.
+pub struct JsonlEventLog {
+    _run_id: Uuid,
+    base_dir: PathBuf,
+    writer: Mutex<BufWriter<File>>,
+}
+
+impl JsonlEventLog {
+    /// Creates a new `JsonlEventLog` with the default base directory.
+    pub fn new(run_id: Uuid) -> Result<Self, crate::run::RouterError> {
+        let base_dir = get_base_dir();
+        Self::new_with_dir(run_id, base_dir)
+    }
+
+    /// Creates a new `JsonlEventLog` with a custom base directory (useful for testing).
+    pub fn new_with_dir(run_id: Uuid, base_dir: PathBuf) -> Result<Self, crate::run::RouterError> {
+        let run_dir = base_dir.join(run_id.to_string());
+        fs::create_dir_all(&run_dir).map_err(|e| {
+            crate::run::RouterError::TimelineError(format!("Failed to create directory: {}", e))
+        })?;
+
+        let file_path = run_dir.join("events.jsonl");
+        let file = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&file_path)
+            .map_err(|e| {
+                crate::run::RouterError::TimelineError(format!("Failed to open event log: {}", e))
+            })?;
+
+        let writer = Mutex::new(BufWriter::new(file));
+
+        Ok(Self {
+            _run_id: run_id,
+            base_dir,
+            writer,
+        })
+    }
+}
+
+impl EventLog for JsonlEventLog {
+    fn append(&self, event: Event) -> Result<(), crate::run::RouterError> {
+        let versioned = VersionedEvent { v: 1, event };
+
+        let mut serialized = serde_json::to_string(&versioned).map_err(|e| {
+            crate::run::RouterError::TimelineError(format!("Serialization error: {}", e))
+        })?;
+        serialized.push('\n');
+
+        let mut guard = self.writer.lock().map_err(|_| {
+            crate::run::RouterError::TimelineError("Mutex poisoned".to_string())
+        })?;
+
+        guard.write_all(serialized.as_bytes()).map_err(|e| {
+            crate::run::RouterError::TimelineError(format!("Write error: {}", e))
+        })?;
+
+        // Atomic/Durability pattern: flush BufWriter to file descriptor
+        guard.flush().map_err(|e| {
+            crate::run::RouterError::TimelineError(format!("Flush error: {}", e))
+        })?;
+
+        // Fsync pattern: persist to disk
+        let file = guard.get_ref();
+        if let Err(e) = file.sync_all() {
+            // "fsync falla: Reportar error, continuar (mejor perder un evento que todo el run)"
+            tracing::warn!("Failed to fsync event log: {}", e);
+        }
+
+        Ok(())
+    }
+
+    fn read_events(&self, run_id: Uuid) -> Result<Vec<Event>, crate::run::RouterError> {
+        let run_dir = self.base_dir.join(run_id.to_string());
+        let file_path = run_dir.join("events.jsonl");
+        if !file_path.exists() {
+            return Ok(Vec::new());
+        }
+
+        let file = File::open(&file_path).map_err(|e| {
+            crate::run::RouterError::TimelineError(format!(
+                "Failed to open event log for reading: {}",
+                e
+            ))
+        })?;
+
+        let reader = BufReader::new(file);
+        let mut lines = Vec::new();
+        for line in reader.lines() {
+            let line = line.map_err(|e| {
+                crate::run::RouterError::TimelineError(format!("Read line error: {}", e))
+            })?;
+            lines.push(line);
+        }
+
+        let mut events = Vec::new();
+        let len = lines.len();
+        for (i, line) in lines.iter().enumerate() {
+            if line.trim().is_empty() {
+                continue;
+            }
+            match serde_json::from_str::<VersionedEvent>(line) {
+                Ok(versioned) => {
+                    events.push(versioned.event);
+                }
+                Err(e) => {
+                    if i == len - 1 {
+                        // "Última línea truncada: Ignorar, loguear warning"
+                        tracing::warn!("Truncated last line in event log ignored: {}", e);
+                    } else {
+                        return Err(crate::run::RouterError::TimelineError(format!(
+                            "Parse error at line {}: {}",
+                            i + 1,
+                            e
+                        )));
+                    }
+                }
+            }
+        }
+
+        Ok(events)
+    }
+
+    fn list_runs(&self) -> Result<Vec<Uuid>, crate::run::RouterError> {
+        if !self.base_dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut run_ids = Vec::new();
+        let entries = fs::read_dir(&self.base_dir).map_err(|e| {
+            crate::run::RouterError::TimelineError(format!("Failed to read base directory: {}", e))
+        })?;
+
+        for entry in entries {
+            let entry = entry.map_err(|e| {
+                crate::run::RouterError::TimelineError(format!("Dir entry error: {}", e))
+            })?;
+            let path = entry.path();
+            if path.is_dir() {
+                if let Some(name_str) = path.file_name().and_then(|s| s.to_str()) {
+                    if let Ok(uuid) = Uuid::parse_str(name_str) {
+                        if path.join("events.jsonl").exists() {
+                            run_ids.push(uuid);
+                        }
+                    }
+                }
+            }
+        }
+        Ok(run_ids)
+    }
+}

--- a/gestalt-router/tests/router_tests.rs
+++ b/gestalt-router/tests/router_tests.rs
@@ -116,3 +116,108 @@ fn test_agent_result_and_report() {
     assert_eq!(report.merged_branches[0], "feature-1");
     assert_eq!(report.events_path, "/tmp/events");
 }
+
+use gestalt_router::timeline::{Event, EventLog, JsonlEventLog, VersionedEvent};
+use std::fs::File;
+use std::io::Write;
+
+fn get_test_temp_dir() -> std::path::PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!("gestalt_test_{}", Uuid::new_v4()));
+    path
+}
+
+#[test]
+fn test_event_serialization_schema_and_adjacent_tagging() {
+    let event = Event::AgentStateChanged {
+        agent_id: "agent-1".to_string(),
+        state: AgentState::Running,
+    };
+    let versioned = VersionedEvent { v: 1, event };
+
+    let serialized = serde_json::to_string(&versioned).unwrap();
+    // It must contain `"v":1`, `"type":"AgentStateChanged"`, and `"payload"`
+    assert!(serialized.contains("\"v\":1"));
+    assert!(serialized.contains("\"type\":\"AgentStateChanged\""));
+    assert!(serialized.contains("\"payload\""));
+    assert!(serialized.contains("\"agent_id\":\"agent-1\""));
+
+    let deserialized: VersionedEvent = serde_json::from_str(&serialized).unwrap();
+    assert_eq!(deserialized.v, 1);
+    match deserialized.event {
+        Event::AgentStateChanged { agent_id, state } => {
+            assert_eq!(agent_id, "agent-1");
+            assert_eq!(state, AgentState::Running);
+        }
+        _ => panic!("Expected AgentStateChanged variant"),
+    }
+}
+
+#[test]
+fn test_jsonl_event_log_roundtrip_and_list_runs() {
+    let temp_dir = get_test_temp_dir();
+    let run_id = Uuid::new_v4();
+
+    let log = JsonlEventLog::new_with_dir(run_id, temp_dir.clone()).unwrap();
+
+    // Appending a few events
+    log.append(Event::RunStarted).unwrap();
+    log.append(Event::AgentStateChanged {
+        agent_id: "agent-abc".to_string(),
+        state: AgentState::Success,
+    }).unwrap();
+    log.append(Event::RunFinished).unwrap();
+
+    // Read events back and verify
+    let events = log.read_events(run_id).unwrap();
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0], Event::RunStarted);
+    assert!(matches!(events[1], Event::AgentStateChanged { .. }));
+    assert_eq!(events[2], Event::RunFinished);
+
+    // List runs and verify
+    let runs = log.list_runs().unwrap();
+    assert_eq!(runs.len(), 1);
+    assert_eq!(runs[0], run_id);
+
+    // Clean up
+    let _ = std::fs::remove_dir_all(temp_dir);
+}
+
+#[test]
+fn test_jsonl_event_log_truncation_recovery() {
+    let temp_dir = get_test_temp_dir();
+    let run_id = Uuid::new_v4();
+
+    // Setup: manually write some valid events and a truncated/malformed last line
+    let run_dir = temp_dir.join(run_id.to_string());
+    std::fs::create_dir_all(&run_dir).unwrap();
+    let file_path = run_dir.join("events.jsonl");
+
+    let mut file = File::create(&file_path).unwrap();
+
+    // Line 1: Valid event
+    let ev1 = VersionedEvent { v: 1, event: Event::RunStarted };
+    let ser1 = serde_json::to_string(&ev1).unwrap();
+    writeln!(file, "{}", ser1).unwrap();
+
+    // Line 2: Valid event
+    let ev2 = VersionedEvent { v: 1, event: Event::SymlinkEscape { path: "/etc/passwd".to_string() } };
+    let ser2 = serde_json::to_string(&ev2).unwrap();
+    writeln!(file, "{}", ser2).unwrap();
+
+    // Line 3: Truncated last line (not valid JSON)
+    writeln!(file, "{{\"v\":1,\"type\":\"RunFinished\"").unwrap(); // missing closing brace
+
+    // Initialize log and read events
+    let log = JsonlEventLog::new_with_dir(run_id, temp_dir.clone()).unwrap();
+    let events = log.read_events(run_id).unwrap();
+
+    // It should tolerate the truncated last line, log a warning, and successfully return the first 2 events!
+    assert_eq!(events.len(), 2);
+    assert_eq!(events[0], Event::RunStarted);
+    assert_eq!(events[1], Event::SymlinkEscape { path: "/etc/passwd".to_string() });
+
+    // Clean up
+    let _ = std::fs::remove_dir_all(temp_dir);
+}


### PR DESCRIPTION
Implemented a persistent, append-only, JSONL-based timeline event logging system for runs under `gestalt-router`. Includes schema versioning, crash recovery with last line truncation tolerance, atomic durability with BufWriter + fsync, and full unit test coverage.

Fixes #301

---
*PR created automatically by Jules for task [5906887102993029386](https://jules.google.com/task/5906887102993029386) started by @iberi22*