### PR TITLE
Add integration tests and core Router implementation for gestalt-router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1780,6 +1780,7 @@ dependencies = [
  "gestalt_core",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
  "tracing",

--- a/gestalt-router/Cargo.toml
+++ b/gestalt-router/Cargo.toml
@@ -11,3 +11,6 @@ thiserror = "1.0.69"
 uuid = { version = "1.15.1", features = ["v4", "serde"] }
 tracing = "0.1.44"
 gestalt_core = { path = "../gestalt_core" }
+
+[dev-dependencies]
+tempfile = "3"

--- a/gestalt-router/src/run.rs
+++ b/gestalt-router/src/run.rs
@@ -1,7 +1,11 @@
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
+use std::sync::Arc;
 use thiserror::Error;
+use tokio::sync::Semaphore;
 use uuid::Uuid;
+use crate::run_state::AgentState;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentSpec {
@@ -25,7 +29,7 @@ pub struct RunSpec {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentResult {
     pub agent_id: String,
-    pub state: crate::run_state::AgentState,
+    pub state: AgentState,
     pub output: Option<String>,
     pub error: Option<String>,
 }
@@ -52,4 +56,329 @@ pub enum RouterError {
 
     #[error("Invalid specification: {0}")]
     InvalidSpec(String),
+}
+
+pub struct Router {
+    pub repo_path: PathBuf,
+}
+
+impl Router {
+    pub fn new(repo_path: PathBuf) -> Self {
+        Self { repo_path }
+    }
+
+    pub async fn execute(&self, spec: RunSpec) -> Result<RunReport, RouterError> {
+        let run_id = Uuid::new_v4();
+        let semaphore = Arc::new(Semaphore::new(spec.max_parallel));
+        let mut join_set = tokio::task::JoinSet::new();
+
+        for agent in &spec.agents {
+            let sem = semaphore.clone();
+            let agent = agent.clone();
+            let repo_path = self.repo_path.clone();
+            let run_id = run_id;
+            let base_ref = spec.base_ref.clone();
+            let timeout_sec = spec.timeout;
+
+            join_set.spawn(async move {
+                let _permit = sem.acquire().await.unwrap();
+                let branch_name = format!("gestalt/run-{}/{}", run_id, agent.id);
+                let worktree_dir_name = format!("gestalt-worktree-{}-{}", run_id, agent.id);
+                let worktree_path = std::env::temp_dir().join(worktree_dir_name);
+
+                // Add Git worktree
+                let worktree_add_res = run_git_cmd(&repo_path, &[
+                    "worktree",
+                    "add",
+                    "-b",
+                    &branch_name,
+                    &worktree_path.to_string_lossy(),
+                    &base_ref,
+                ]);
+
+                if let Err(e) = worktree_add_res {
+                    return AgentResult {
+                        agent_id: agent.id.clone(),
+                        state: AgentState::Crashed,
+                        output: None,
+                        error: Some(format!("Failed to create git worktree: {}", e)),
+                    };
+                }
+
+                // Execute agent process
+                let mut cmd = tokio::process::Command::new(&agent.command);
+                cmd.args(&agent.args)
+                    .current_dir(&worktree_path)
+                    .envs(&agent.env)
+                    .stdout(std::process::Stdio::piped())
+                    .stderr(std::process::Stdio::piped());
+
+                let child = match cmd.spawn() {
+                    Ok(c) => c,
+                    Err(e) => {
+                        let _ = run_git_cmd(&repo_path, &[
+                            "worktree",
+                            "remove",
+                            "--force",
+                            &worktree_path.to_string_lossy(),
+                        ]);
+                        let _ = std::fs::remove_dir_all(&worktree_path);
+                        return AgentResult {
+                            agent_id: agent.id.clone(),
+                            state: AgentState::Crashed,
+                            output: None,
+                            error: Some(format!("Failed to spawn agent process: {}", e)),
+                        };
+                    }
+                };
+
+                let pid = child.id();
+
+                // Wait with timeout using select!
+                let timeout_duration = std::time::Duration::from_secs(timeout_sec);
+
+                let (mut state, output, error) = tokio::select! {
+                    wait_res = child.wait_with_output() => {
+                        match wait_res {
+                            Ok(output_val) => {
+                                let stdout = String::from_utf8_lossy(&output_val.stdout).into_owned();
+                                let stderr = String::from_utf8_lossy(&output_val.stderr).into_owned();
+                                let full_output = format!("{}\n{}", stdout, stderr);
+                                if output_val.status.success() {
+                                    (AgentState::Success, Some(full_output), None)
+                                } else {
+                                    let code = output_val.status.code().unwrap_or(-1);
+                                    (
+                                        AgentState::Crashed,
+                                        Some(full_output),
+                                        Some(format!("Agent process exited with code {}", code)),
+                                    )
+                                }
+                            }
+                            Err(e) => {
+                                (AgentState::Crashed, None, Some(format!("Failed to wait for agent process: {}", e)))
+                            }
+                        }
+                    }
+                    _ = tokio::time::sleep(timeout_duration) => {
+                        if let Some(p) = pid {
+                            let _ = std::process::Command::new("kill")
+                                .arg("-9")
+                                .arg(p.to_string())
+                                .status();
+                        }
+                        (
+                            AgentState::Timeout,
+                            None,
+                            Some("Agent process timed out and was killed".to_string()),
+                        )
+                    }
+                };
+
+                let mut has_changes = false;
+                if state == AgentState::Success {
+                    let mut escaped_symlinks = Vec::new();
+                    scan_for_symlink_escapes(&worktree_path, &worktree_path, &mut escaped_symlinks);
+                    if !escaped_symlinks.is_empty() {
+                        state = AgentState::Quarantined;
+                        for esc in escaped_symlinks {
+                            let _ = std::fs::remove_file(esc);
+                        }
+                    }
+
+                    if let Ok(status_out) = run_git_cmd(&worktree_path, &["status", "--porcelain"]) {
+                        if !status_out.trim().is_empty() {
+                            has_changes = true;
+                            let _ = run_git_cmd(&worktree_path, &["add", "-A"]);
+                            let _ = run_git_cmd(&worktree_path, &[
+                                "commit",
+                                "-m",
+                                &format!("feat(agent-{}): updates", agent.id),
+                            ]);
+                        }
+                    }
+
+                    if !has_changes && state == AgentState::Success {
+                        state = AgentState::NoChanges;
+                    }
+                }
+
+                // Cleanup worktree
+                let _ = run_git_cmd(&repo_path, &[
+                    "worktree",
+                    "remove",
+                    "--force",
+                    &worktree_path.to_string_lossy(),
+                ]);
+                if worktree_path.exists() {
+                    let _ = std::fs::remove_dir_all(&worktree_path);
+                }
+
+                AgentResult {
+                    agent_id: agent.id,
+                    state,
+                    output,
+                    error,
+                }
+            });
+        }
+
+        let mut agent_results = Vec::new();
+        while let Some(res) = join_set.join_next().await {
+            if let Ok(agent_res) = res {
+                agent_results.push(agent_res);
+            }
+        }
+
+        // Sort agent_results to match the original order of spec.agents
+        let agent_order: HashMap<String, usize> = spec
+            .agents
+            .iter()
+            .enumerate()
+            .map(|(i, a)| (a.id.clone(), i))
+            .collect();
+        agent_results.sort_by_key(|r| agent_order.get(&r.agent_id).copied().unwrap_or(usize::MAX));
+
+        let mut merged_branches = Vec::new();
+        let mut conflicts = Vec::new();
+
+        // Checkout integration branch from base_ref
+        if let Err(e) = run_git_cmd(&self.repo_path, &[
+            "checkout",
+            "-B",
+            &spec.integration_branch,
+            &spec.base_ref,
+        ]) {
+            return Err(RouterError::GitError(format!(
+                "Failed to checkout integration branch: {}",
+                e
+            )));
+        }
+
+        // Sequentially merge each successful/quarantined agent branch
+        for result in &agent_results {
+            if result.state == AgentState::Success || result.state == AgentState::Quarantined {
+                let branch_name = format!("gestalt/run-{}/{}", run_id, result.agent_id);
+
+                match run_git_cmd(&self.repo_path, &[
+                    "merge",
+                    "--no-ff",
+                    "-m",
+                    &format!("Merge agent-{}", result.agent_id),
+                    &branch_name,
+                ]) {
+                    Ok(_) => {
+                        merged_branches.push(branch_name);
+                    }
+                    Err(_) => {
+                        if let Ok(conflicted_out) = run_git_cmd(&self.repo_path, &[
+                            "diff",
+                            "--name-only",
+                            "--diff-filter=U",
+                        ]) {
+                            for line in conflicted_out.lines() {
+                                let path_str = line.trim().to_string();
+                                if !path_str.is_empty() && !conflicts.contains(&path_str) {
+                                    conflicts.push(path_str);
+                                }
+                            }
+                        }
+                        let _ = run_git_cmd(&self.repo_path, &["merge", "--abort"]);
+                    }
+                }
+            }
+        }
+
+        // Checkout back to base_ref to restore state
+        let _ = run_git_cmd(&self.repo_path, &["checkout", &spec.base_ref]);
+
+        let events_path = std::env::temp_dir()
+            .join(format!("run-{}.jsonl", run_id))
+            .to_string_lossy()
+            .into_owned();
+
+        Ok(RunReport {
+            run_id,
+            agents: agent_results,
+            merged_branches,
+            conflicts,
+            events_path,
+        })
+    }
+}
+
+fn run_git_cmd(repo_path: &Path, args: &[&str]) -> Result<String, String> {
+    let output = std::process::Command::new("git")
+        .args(args)
+        .current_dir(repo_path)
+        .output()
+        .map_err(|e| e.to_string())?;
+
+    if output.status.success() {
+        Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+    } else {
+        Err(String::from_utf8_lossy(&output.stderr).trim().to_string())
+    }
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    let mut components = Vec::new();
+    let mut is_absolute = path.is_absolute();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                components.pop();
+            }
+            Component::CurDir => {}
+            Component::Normal(c) => {
+                components.push(c);
+            }
+            Component::RootDir => {
+                is_absolute = true;
+            }
+            _ => {}
+        }
+    }
+    let mut result = PathBuf::new();
+    if is_absolute {
+        result.push("/");
+    }
+    for c in components {
+        result.push(c);
+    }
+    result
+}
+
+fn is_symlink_escape(worktree_root: &Path, file_path: &Path) -> bool {
+    if let Ok(target) = std::fs::read_link(file_path) {
+        let resolved = if target.is_absolute() {
+            target
+        } else {
+            let parent = file_path.parent().unwrap_or(worktree_root);
+            parent.join(target)
+        };
+        let norm_root = normalize_path(worktree_root);
+        let norm_resolved = normalize_path(&resolved);
+        if !norm_resolved.starts_with(&norm_root) {
+            return true;
+        }
+    }
+    false
+}
+
+fn scan_for_symlink_escapes(dir: &Path, current_dir: &Path, escaped_symlinks: &mut Vec<PathBuf>) {
+    if let Ok(entries) = std::fs::read_dir(current_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if let Ok(metadata) = std::fs::symlink_metadata(&path) {
+                if metadata.file_type().is_symlink() {
+                    if is_symlink_escape(dir, &path) {
+                        escaped_symlinks.push(path.clone());
+                    }
+                } else if metadata.is_dir() {
+                    scan_for_symlink_escapes(dir, &path, escaped_symlinks);
+                }
+            }
+        }
+    }
 }

--- a/gestalt-router/tests/integration_test.rs
+++ b/gestalt-router/tests/integration_test.rs
@@ -1,0 +1,238 @@
+use gestalt_router::run::{AgentSpec, Router, RunSpec};
+use gestalt_router::run_state::AgentState;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+fn init_test_repo() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    let repo_path = dir.path().to_path_buf();
+
+    // Init git repo
+    let status = std::process::Command::new("git")
+        .arg("init")
+        .current_dir(&repo_path)
+        .status()
+        .unwrap();
+    assert!(status.success());
+
+    // Configure local git user
+    std::process::Command::new("git")
+        .args(&["config", "user.name", "Gestalt Tester"])
+        .current_dir(&repo_path)
+        .status()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(&["config", "user.email", "tester@gestalt.local"])
+        .current_dir(&repo_path)
+        .status()
+        .unwrap();
+
+    // Create 2 initial files
+    let file1 = repo_path.join("file1.txt");
+    std::fs::write(&file1, "Line 1 of file 1\nLine 2 of file 1\n").unwrap();
+
+    let file2 = repo_path.join("file2.txt");
+    std::fs::write(&file2, "Line 1 of file 2\nLine 2 of file 2\n").unwrap();
+
+    // Commit initial state
+    std::process::Command::new("git")
+        .arg("add")
+        .arg(".")
+        .current_dir(&repo_path)
+        .status()
+        .unwrap();
+    std::process::Command::new("git")
+        .args(&["commit", "-m", "Initial commit"])
+        .current_dir(&repo_path)
+        .status()
+        .unwrap();
+
+    // Checkout main branch
+    std::process::Command::new("git")
+        .args(&["checkout", "-B", "main"])
+        .current_dir(&repo_path)
+        .status()
+        .unwrap();
+
+    (dir, repo_path)
+}
+
+#[tokio::test]
+async fn test_merge_clean_different_files() {
+    let (_dir, repo_path) = init_test_repo();
+    let router = Router::new(repo_path.clone());
+
+    // Agent 1 modifies file1.txt
+    let agent1 = AgentSpec {
+        id: "agent-1".to_string(),
+        command: "sh".to_string(),
+        args: vec!["-c".to_string(), "echo 'Agent 1 change' >> file1.txt".to_string()],
+        allowed_paths: vec![],
+        env: HashMap::new(),
+    };
+
+    // Agent 2 modifies file2.txt
+    let agent2 = AgentSpec {
+        id: "agent-2".to_string(),
+        command: "sh".to_string(),
+        args: vec!["-c".to_string(), "echo 'Agent 2 change' >> file2.txt".to_string()],
+        allowed_paths: vec![],
+        env: HashMap::new(),
+    };
+
+    let spec = RunSpec {
+        base_ref: "main".to_string(),
+        task: "Refactor distinct files".to_string(),
+        agents: vec![agent1, agent2],
+        integration_branch: "gestalt/integration-test-clean".to_string(),
+        timeout: 15,
+        max_parallel: 2,
+    };
+
+    let report = router.execute(spec).await.unwrap();
+
+    // Verify Agent 1 and Agent 2 results
+    assert_eq!(report.agents.len(), 2);
+    assert_eq!(report.agents[0].agent_id, "agent-1");
+    assert_eq!(report.agents[0].state, AgentState::Success);
+    assert_eq!(report.agents[1].agent_id, "agent-2");
+    assert_eq!(report.agents[1].state, AgentState::Success);
+
+    // Verify merge and branch integration
+    assert_eq!(report.conflicts.len(), 0);
+    assert_eq!(report.merged_branches.len(), 2);
+
+    // Checkout integration branch in main repo to verify actual content merged
+    std::process::Command::new("git")
+        .args(&["checkout", "gestalt/integration-test-clean"])
+        .current_dir(&repo_path)
+        .status()
+        .unwrap();
+
+    let content1 = std::fs::read_to_string(repo_path.join("file1.txt")).unwrap();
+    let content2 = std::fs::read_to_string(repo_path.join("file2.txt")).unwrap();
+
+    assert!(content1.contains("Agent 1 change"));
+    assert!(content2.contains("Agent 2 change"));
+}
+
+#[tokio::test]
+async fn test_merge_conflict_same_region() {
+    let (_dir, repo_path) = init_test_repo();
+    let router = Router::new(repo_path.clone());
+
+    // Agent 1 overwrites file1.txt to A
+    let agent1 = AgentSpec {
+        id: "agent-1".to_string(),
+        command: "sh".to_string(),
+        args: vec!["-c".to_string(), "echo 'Conflict A' > file1.txt".to_string()],
+        allowed_paths: vec![],
+        env: HashMap::new(),
+    };
+
+    // Agent 2 overwrites file1.txt to B
+    let agent2 = AgentSpec {
+        id: "agent-2".to_string(),
+        command: "sh".to_string(),
+        args: vec!["-c".to_string(), "echo 'Conflict B' > file1.txt".to_string()],
+        allowed_paths: vec![],
+        env: HashMap::new(),
+    };
+
+    let spec = RunSpec {
+        base_ref: "main".to_string(),
+        task: "Conflicting edits on same file".to_string(),
+        agents: vec![agent1, agent2],
+        integration_branch: "gestalt/integration-test-conflict".to_string(),
+        timeout: 15,
+        max_parallel: 2,
+    };
+
+    let report = router.execute(spec).await.unwrap();
+
+    // Verify results
+    assert_eq!(report.agents.len(), 2);
+    assert_eq!(report.agents[0].state, AgentState::Success);
+    assert_eq!(report.agents[1].state, AgentState::Success);
+
+    // One merge should succeed, and the other should result in conflict
+    assert_eq!(report.merged_branches.len(), 1);
+    assert_eq!(report.conflicts.len(), 1);
+    assert_eq!(report.conflicts[0], "file1.txt");
+}
+
+#[tokio::test]
+async fn test_agent_timeout_sigkill() {
+    let (_dir, repo_path) = init_test_repo();
+    let router = Router::new(repo_path);
+
+    // Agent runs a slow command that exceeds the timeout
+    let slow_agent = AgentSpec {
+        id: "slow-agent".to_string(),
+        command: "sleep".to_string(),
+        args: vec!["10".to_string()],
+        allowed_paths: vec![],
+        env: HashMap::new(),
+    };
+
+    let spec = RunSpec {
+        base_ref: "main".to_string(),
+        task: "Timeout test".to_string(),
+        agents: vec![slow_agent],
+        integration_branch: "gestalt/integration-test-timeout".to_string(),
+        timeout: 1, // Only 1 second timeout
+        max_parallel: 1,
+    };
+
+    let report = router.execute(spec).await.unwrap();
+
+    assert_eq!(report.agents.len(), 1);
+    assert_eq!(report.agents[0].agent_id, "slow-agent");
+    assert_eq!(report.agents[0].state, AgentState::Timeout);
+    assert!(report.agents[0].error.as_ref().unwrap().contains("timed out"));
+    assert_eq!(report.merged_branches.len(), 0);
+}
+
+#[tokio::test]
+async fn test_symlink_escape_detection() {
+    let (_dir, repo_path) = init_test_repo();
+    let router = Router::new(repo_path.clone());
+
+    // Agent attempts to create an escaping symlink and a legit change
+    let malicious_agent = AgentSpec {
+        id: "escape-agent".to_string(),
+        command: "sh".to_string(),
+        args: vec![
+            "-c".to_string(),
+            "ln -s /etc/passwd escape.txt && echo 'legit' > legit.txt".to_string(),
+        ],
+        allowed_paths: vec![],
+        env: HashMap::new(),
+    };
+
+    let spec = RunSpec {
+        base_ref: "main".to_string(),
+        task: "Symlink escape test".to_string(),
+        agents: vec![malicious_agent],
+        integration_branch: "gestalt/integration-test-symlink".to_string(),
+        timeout: 15,
+        max_parallel: 1,
+    };
+
+    let report = router.execute(spec).await.unwrap();
+
+    assert_eq!(report.agents.len(), 1);
+    assert_eq!(report.agents[0].agent_id, "escape-agent");
+    assert_eq!(report.agents[0].state, AgentState::Quarantined);
+    assert_eq!(report.merged_branches.len(), 1);
+
+    // Checkout integration branch and verify that legit.txt exists but escape.txt does not!
+    std::process::Command::new("git")
+        .args(&["checkout", "gestalt/integration-test-symlink"])
+        .current_dir(&repo_path)
+        .status()
+        .unwrap();
+
+    assert!(repo_path.join("legit.txt").exists());
+    assert!(!repo_path.join("escape.txt").exists());
+}


### PR DESCRIPTION
Added comprehensive integration and acceptance tests for the `gestalt-router` crate in `gestalt-router/tests/integration_test.rs` using a temporary git repository fixture. Implemented the corresponding `Router` orchestrator struct and `Router::execute` pipeline in `gestalt-router/src/run.rs` to support git worktree isolation, process timeout SIGKILL, symlink escape detection/quarantine, and sequential merge conflict reporting. Added `tempfile` as a dev-dependency. All unit and integration tests compile and pass successfully.

Fixes #306

---
*PR created automatically by Jules for task [7717968871750156932](https://jules.google.com/task/7717968871750156932) started by @iberi22*