### PR TITLE
Implement core base types for gestalt-router

### DIFF
--- a/gestalt-router/src/run.rs
+++ b/gestalt-router/src/run.rs
@@ -8,8 +8,8 @@ pub struct AgentSpec {
     pub id: String,
     pub command: String,
     pub args: Vec<String>,
-    pub allowed_paths: Vec<String>,
-    pub env: HashMap<String, String>,
+    pub allowed_paths: Option<Vec<String>>,
+    pub env: Option<HashMap<String, String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -17,39 +17,85 @@ pub struct RunSpec {
     pub base_ref: String,
     pub task: String,
     pub agents: Vec<AgentSpec>,
-    pub integration_branch: String,
-    pub timeout: u64,
     pub max_parallel: usize,
+    pub timeout: u64,
+    pub push: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum AgentStatus {
+    Pending,
+    Running,
+    Success,
+    Timeout,
+    Crashed,
+    NoChanges,
+    Quarantined,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentResult {
     pub agent_id: String,
-    pub state: crate::run_state::AgentState,
-    pub output: Option<String>,
-    pub error: Option<String>,
+    pub status: AgentStatus,
+    pub exit_code: Option<i32>,
+    pub changed_files: Vec<String>,
+    pub branch: String,
+    pub duration_ms: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ConflictKind {
+    Overlap,
+    MergeConflict,
+    BinaryConflict,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConflictInfo {
+    pub path: String,
+    pub agent_a: String,
+    pub agent_b: String,
+    pub kind: ConflictKind,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunReport {
     pub run_id: Uuid,
+    pub base_sha: String,
     pub agents: Vec<AgentResult>,
-    pub merged_branches: Vec<String>,
-    pub conflicts: Vec<String>,
+    pub integration_branch: String,
+    pub conflicts: Vec<ConflictInfo>,
     pub events_path: String,
+    pub success: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum RouterErrorKind {
+    GitError,
+    AgentError,
+    Timeout,
+    InvalidSpec,
 }
 
 #[derive(Debug, Error)]
-pub enum RouterError {
-    #[error("Git error: {0}")]
-    GitError(String),
+#[error("{message}")]
+pub struct RouterError {
+    pub kind: RouterErrorKind,
+    pub message: String,
+    #[source]
+    pub source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+}
 
-    #[error("Agent error: {0}")]
-    AgentError(String),
-
-    #[error("Timeout error")]
-    Timeout,
-
-    #[error("Invalid specification: {0}")]
-    InvalidSpec(String),
+impl RouterError {
+    pub fn new(
+        kind: RouterErrorKind,
+        message: impl Into<String>,
+        source: Option<Box<dyn std::error::Error + Send + Sync + 'static>>,
+    ) -> Self {
+        Self {
+            kind,
+            message: message.into(),
+            source,
+        }
+    }
 }

--- a/gestalt-router/src/run_state.rs
+++ b/gestalt-router/src/run_state.rs
@@ -3,16 +3,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum AgentState {
-    Pending,
-    Running,
-    Success,
-    Timeout,
-    Crashed,
-    NoChanges,
-    Quarantined,
-}
+pub use crate::run::AgentStatus as AgentState;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RunManifest {

--- a/gestalt-router/tests/router_tests.rs
+++ b/gestalt-router/tests/router_tests.rs
@@ -1,4 +1,7 @@
-use gestalt_router::run::{AgentResult, AgentSpec, RouterError, RunReport, RunSpec};
+use gestalt_router::run::{
+    AgentResult, AgentSpec, AgentStatus, ConflictInfo, ConflictKind, RouterError, RouterErrorKind,
+    RunReport, RunSpec,
+};
 use gestalt_router::run_state::{AgentState, RunManifest};
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -19,17 +22,17 @@ fn test_run_spec_serialization() {
         id: "agent-1".to_string(),
         command: "echo".to_string(),
         args: vec!["hello".to_string()],
-        allowed_paths: vec!["/tmp".to_string()],
-        env: HashMap::from([("KEY".to_string(), "VALUE".to_string())]),
+        allowed_paths: Some(vec!["/tmp".to_string()]),
+        env: Some(HashMap::from([("KEY".to_string(), "VALUE".to_string())])),
     };
 
     let spec = RunSpec {
         base_ref: "main".to_string(),
         task: "test task".to_string(),
         agents: vec![agent],
-        integration_branch: "integration-1".to_string(),
         timeout: 3600,
         max_parallel: 2,
+        push: true,
     };
 
     let serialized = serde_json::to_string(&spec).unwrap();
@@ -41,11 +44,22 @@ fn test_run_spec_serialization() {
     assert_eq!(deserialized.agents[0].id, "agent-1");
     assert_eq!(deserialized.agents[0].command, "echo");
     assert_eq!(deserialized.agents[0].args[0], "hello");
-    assert_eq!(deserialized.agents[0].allowed_paths[0], "/tmp");
-    assert_eq!(deserialized.agents[0].env.get("KEY").unwrap(), "VALUE");
-    assert_eq!(deserialized.integration_branch, "integration-1");
+    assert_eq!(
+        deserialized.agents[0].allowed_paths.as_ref().unwrap()[0],
+        "/tmp"
+    );
+    assert_eq!(
+        deserialized.agents[0]
+            .env
+            .as_ref()
+            .unwrap()
+            .get("KEY")
+            .unwrap(),
+        "VALUE"
+    );
     assert_eq!(deserialized.timeout, 3600);
     assert_eq!(deserialized.max_parallel, 2);
+    assert!(deserialized.push);
 }
 
 #[test]
@@ -54,9 +68,9 @@ fn test_run_manifest() {
         base_ref: "main".to_string(),
         task: "task".to_string(),
         agents: vec![],
-        integration_branch: "int".to_string(),
         timeout: 100,
         max_parallel: 1,
+        push: false,
     };
 
     let run_id = Uuid::new_v4();
@@ -81,16 +95,20 @@ fn test_run_manifest() {
 
 #[test]
 fn test_router_error_display() {
-    let err = RouterError::GitError("failed to merge".to_string());
+    let err = RouterError::new(RouterErrorKind::GitError, "Git error: failed to merge", None);
     assert_eq!(err.to_string(), "Git error: failed to merge");
 
-    let err2 = RouterError::AgentError("agent crashed".to_string());
+    let err2 = RouterError::new(RouterErrorKind::AgentError, "Agent error: agent crashed", None);
     assert_eq!(err2.to_string(), "Agent error: agent crashed");
 
-    let err3 = RouterError::Timeout;
+    let err3 = RouterError::new(RouterErrorKind::Timeout, "Timeout error", None);
     assert_eq!(err3.to_string(), "Timeout error");
 
-    let err4 = RouterError::InvalidSpec("missing command".to_string());
+    let err4 = RouterError::new(
+        RouterErrorKind::InvalidSpec,
+        "Invalid specification: missing command",
+        None,
+    );
     assert_eq!(err4.to_string(), "Invalid specification: missing command");
 }
 
@@ -98,21 +116,47 @@ fn test_router_error_display() {
 fn test_agent_result_and_report() {
     let result = AgentResult {
         agent_id: "agent-1".to_string(),
-        state: AgentState::Success,
-        output: Some("done".to_string()),
-        error: None,
+        status: AgentStatus::Success,
+        exit_code: Some(0),
+        changed_files: vec!["src/main.rs".to_string()],
+        branch: "agent-branch-1".to_string(),
+        duration_ms: 125,
+    };
+
+    let conflict = ConflictInfo {
+        path: "src/main.rs".to_string(),
+        agent_a: "agent-1".to_string(),
+        agent_b: "agent-2".to_string(),
+        kind: ConflictKind::Overlap,
     };
 
     let report = RunReport {
         run_id: Uuid::new_v4(),
+        base_sha: "abcdef123456".to_string(),
         agents: vec![result],
-        merged_branches: vec!["feature-1".to_string()],
-        conflicts: vec![],
+        integration_branch: "feature-1".to_string(),
+        conflicts: vec![conflict],
         events_path: "/tmp/events".to_string(),
+        success: true,
     };
 
-    assert_eq!(report.agents[0].agent_id, "agent-1");
-    assert_eq!(report.agents[0].state, AgentState::Success);
-    assert_eq!(report.merged_branches[0], "feature-1");
-    assert_eq!(report.events_path, "/tmp/events");
+    let serialized = serde_json::to_string(&report).unwrap();
+    let deserialized: RunReport = serde_json::from_str(&serialized).unwrap();
+
+    assert_eq!(deserialized.run_id, report.run_id);
+    assert_eq!(deserialized.base_sha, report.base_sha);
+    assert_eq!(deserialized.agents[0].agent_id, "agent-1");
+    assert_eq!(deserialized.agents[0].status, AgentStatus::Success);
+    assert_eq!(deserialized.agents[0].exit_code, Some(0));
+    assert_eq!(deserialized.agents[0].changed_files[0], "src/main.rs");
+    assert_eq!(deserialized.agents[0].branch, "agent-branch-1");
+    assert_eq!(deserialized.agents[0].duration_ms, 125);
+
+    assert_eq!(deserialized.integration_branch, "feature-1");
+    assert_eq!(deserialized.conflicts[0].path, "src/main.rs");
+    assert_eq!(deserialized.conflicts[0].agent_a, "agent-1");
+    assert_eq!(deserialized.conflicts[0].agent_b, "agent-2");
+    assert_eq!(deserialized.conflicts[0].kind, ConflictKind::Overlap);
+    assert_eq!(deserialized.events_path, "/tmp/events");
+    assert!(deserialized.success);
 }


### PR DESCRIPTION
This PR defines and updates the core base types for orchestration routing in gestalt-router, implementing RunSpec, AgentSpec, AgentResult, RunReport, RouterError, AgentStatus, ConflictInfo, ConflictKind, and RouterErrorKind with Serialize, Deserialize, Display, and Debug traits as specified. Also refactors state management to align with the new types and updates integration tests.

Fixes #303

---
*PR created automatically by Jules for task [12242039001696438941](https://jules.google.com/task/12242039001696438941) started by @iberi22*