### PR TITLE
Documentation update — README, SRC.md, AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,87 +1,51 @@
-# Gestalt — Agent Developer Guide
+# AGENTS.md — Gestalt Agent Design Non-Negotiables
 
-## Project Overview
+Welcome! This document outlines the absolute design non-negotiables (reglas inquebrantables de diseño) for developers creating, extending, or maintaining agents within the Gestalt framework.
 
-Gestalt is a **multi-agent orchestration framework** written in Rust. It provides:
-- A REPL/CLI interface (`gestalt_cli`)
-- Core agent framework (`gestalt_core`)
-- Timeline tracking (`gestalt_timeline`)
-- Swarm capabilities (`gestalt_swarm`)
+## 🛑 Design Non-Negotiables
 
-## Key Packages
+### 1. VFS Isolation & Sandboxing
+- **Always Use OverlayFs:** Agents must never write directly to the local host filesystem outside of their designated, isolated VFS overlay. All reads and writes must go through the VFS port (`gestalt_core::ports::outbound::vfs`).
+- **No Path Escaping:** Path traversal or escaping above the virtual root is strictly prohibited. Security and sandboxing are foundational design goals.
 
-| Package | Purpose | Entry Point |
-|---|---|---|
-| `gestalt_cli` | CLI binary & REPL | `gestalt_cli/src/main.rs` |
-| `gestalt_core` | Core agent tools, tools, context | `gestalt_core/src/` |
-| `gestalt_timeline` | Event timeline tracking | `gestalt_timeline/src/` |
-| `gestalt_swarm` | Multi-agent swarm logic | `gestalt_swarm/src/` |
-| `synapse-agentic` | Agentic primitives | `synapse-agentic/src/` |
+### 2. Deterministic State Management
+- **Strict State Transitions:** Every agent execution run must map cleanly onto `AgentState` enum values (`Pending`, `Running`, `Success`, `Timeout`, `Crashed`, `NoChanges`, `Quarantined`).
+- **Run Manifests:** Agent state changes must be updated deterministically inside the central `RunManifest`. State must never be kept solely in-memory or in local transient variables.
 
-## Building
+### 3. Isolated Code Integration
+- **Feature Branch Integration:** Agents work in isolated feature/worktree branches. Integration to the target or `integration_branch` must go through the proper router merge flow (`gestalt-merge` or orchestration router).
+- **No Direct Main Commits:** Direct unvalidated commits to production/main branches of primary workspaces are prohibited.
 
+### 4. LLM Provider Resilience & Failover
+- **Automatic Fallbacks:** Any LLM caller must utilize the resilience layer to gracefully fall back (e.g., from OpenAI to Anthropic/DeepSeek) on credential errors or API timeouts.
+- **Fail Gracefully:** Never panic or crash due to rate-limiting or service-down events; always capture structured error logs and return a clean failure/timeout agent state.
+
+### 5. Workspace Crate Exclusion
+- **No gestalt_swarm workspace inclusion:** The `gestalt_swarm` package is explicitly excluded from the Cargo workspace members in `Cargo.toml` to prevent compilation/link errors regarding `GroqProvider` or `synapse-agentic`. Keep it excluded.
+
+---
+
+## 🚀 Key Framework Packages
+
+| Package | Purpose | Path |
+|---------|---------|------|
+| `gestalt_core` | Core domain, VFS, LLM adapters, registry | `gestalt_core/` |
+| `gestalt_cli` | CLI REPL and agent commands | `gestalt_cli/` |
+| `gestalt-router` | Orchestration specs, routing, run states | `gestalt-router/` |
+| `gestalt-merge` | Isolated branch merging and conflict resolution | `gestalt-merge/` |
+| `synapse-agentic` | Primitive agent tools and provider clients | `synapse-agentic/` |
+
+## 🛠️ Essential Development Tasks
+
+### Running Router Tests
+Ensure all orchestration router unit and integration tests are passing:
 ```bash
-# Full project (all crates)
-cargo build --release
-
-# CLI only (most common)
-cargo build --release -p gestalt_cli
-
-# Run the CLI
-cargo run --release -p gestalt_cli -- serve --host 0.0.0.0 --port 10000
+cargo test -p gestalt-router
 ```
 
-## Running
-
+### Formatting & Linting
+Enforce style guidelines across the workspace:
 ```bash
-# REPL mode
-cargo run --release -p gestalt_cli
-
-# Serve mode (HTTP API)
-cargo run --release -p gestalt_cli -- serve --host 0.0.0.0 --port 10000
-```
-
-## Environment Variables
-
-| Variable | Required | Description |
-|---|---|---|
-| `DEEPSEEK_API_KEY` | Yes | DeepSeek API key for LLM calls |
-| `RUST_LOG` | No | Log level, e.g. `info` or `debug` |
-
-## Common Tasks
-
-### Run Tests
-```bash
-cargo test -p gestalt_core --all-targets
-cargo test -p gestalt_cli --all-targets
-cargo test -p gestalt_timeline --lib
-```
-
-### Format & Lint
-```bash
-cargo fmt --all
+cargo fmt --all --check
 cargo clippy --all-targets -- -D warnings
 ```
-
-### Check for Security Vulnerabilities
-```bash
-cargo audit
-```
-
-## Build Errors
-
-If you see `async fn is not permitted in Rust 2015`, the crate is using Rust 2021 edition. Make sure your toolchain supports 2021:
-```bash
-rustup update stable
-```
-
-## Render Deployment
-
-The `render.yaml` file defines the Render blueprint. Build/start commands for the service:
-
-```
-Build: cargo build --release -p gestalt_cli
-Start: ./target/release/gestalt_cli serve --host 0.0.0.0 --port 10000
-```
-
-Required environment variable: `DEEPSEEK_API_KEY`

--- a/README.md
+++ b/README.md
@@ -4,71 +4,72 @@
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Rust](https://img.shields.io/badge/Rust-1.75+-orange.svg)](https://www.rust-lang.org)
+[![Build Status](https://github.com/iberi22/gestalt-rust/actions/workflows/ci.yml/badge.svg)](https://github.com/iberi22/gestalt-rust/actions/workflows/ci.yml)
 
-**Gestalt** is a high-performance Rust workspace for orchestrating AI agents via CLI. It provides VFS isolation, Swarm parallel execution, timeline-based state, and tool registries — all controlled through a REPL or direct CLI.
+**Gestalt** is a high-performance Rust workspace for orchestrating AI agents. It provides VFS isolation, parallel agent routing, state management, and tool registries — all controlled through a REPL or direct CLI.
 
 ## 🚀 Quick Start
 
+### Build and Install CLI
 ```bash
-# Build
-cargo build --release -p gestalt_timeline
+# Build the CLI
+cargo build --release -p gestalt_cli
 
-# Run the orchestrator (gestalt binary)
-cargo run -p gestalt_timeline --bin gestalt
-
-# Or use the CLI REPL
-cargo run -p gestalt_cli
+# Run the CLI REPL
+cargo run -p gestalt_cli -- repl
 ```
 
-## 🐝 Gestalt Swarm
-
-Parallel agent execution bridge. Spawns multiple CLI agents concurrently for high-speed automation.
-
+### Running Multi-Agent Orchestration Router
+Run agents in parallel or route them specifically:
 ```bash
-# Run with N agents
-cargo run --release -p gestalt_swarm -- --agents 4 --goal "analyze codebase security"
-```
+# Run a specific task across multiple agents
+gestalt run --agents agy,claude "implement custom logger in gestalt-router"
 
-See [skills/gestalt-swarm.md](skills/gestalt-swarm.md) for full usage.
+# Run with custom agent selections for a specialized task
+gestalt run --agents agy,claude "audit security-events workflow in CI"
+```
 
 ## 🧩 Crates
 
 | Crate | Type | Description |
 |-------|------|-------------|
 | `gestalt_core` | lib | VFS, auth, LLM adapters, agent tools, MCP client |
-| `gestalt_timeline` | bin | Main orchestrator (`gestalt` binary) + timeline service |
 | `gestalt_cli` | bin | REPL + CLI commands |
-| `gestalt_swarm` | bin | Swarm coordinator for parallel agent execution |
+| `gestalt-router` | lib | Multi-agent orchestration routing & state |
+| `gestalt-merge` | lib | Code integration & branch merging algorithms |
 | `synapse-agentic` | lib | Tool registry + agentic primitives (Hive, LLM providers) |
 
 ## 📂 Project Structure
 
 ```
 gestalt-rust/
-├── Cargo.toml                  # Workspace root (5 crates)
+├── Cargo.toml                  # Workspace root
 ├── gestalt_core/               # Core domain: VFS, auth, LLM, tools
 │   └── src/
-│       ├── adapters/          # MCP client, auth (Google OAuth/PKCE)
+│       ├── adapters/           # MCP client, auth (Google OAuth/PKCE)
 │       ├── application/        # Agent tools, config, indexer
-│       ├── domain/            # Rag embeddings, models
-│       ├── mcp/               # MCP client + registry
-│       └── ports/             # Inbound/outbound port traits
+│       ├── domain/             # Rag embeddings, models
+│       ├── mcp/                # MCP client + registry
+│       └── ports/              # Inbound/outbound port traits
 │           └── outbound/vfs.rs # VFS trait + OverlayFs
-├── gestalt_timeline/           # Orchestrator binary
-│   └── src/main.rs            # gestalt CLI entry point
-├── gestalt_cli/                # Standalone REPL binary
-├── gestalt_swarm/              # Swarm coordinator binary
+├── gestalt_cli/                # Standalone CLI & REPL binary
+├── gestalt-router/             # Multi-agent orchestrator router
+│   └── src/
+│       ├── lib.rs              # Router entrypoint
+│       ├── run.rs              # Run spec and execution types
+│       └── run_state.rs        # Orchestrator & agent state transitions
+├── gestalt-merge/              # Code integration & merge handlers
 ├── synapse-agentic/            # Tool registry + Hive actor model
 ├── skills/                     # OpenClaw skill docs
 ├── docs/                       # Architecture & guides
-└── .gitcore/                  # Git-Core planning docs
+└── .gitcore/                   # Git-Core planning docs
 ```
 
 ## 🔑 Key Features
 
 - **VFS Overlay** — Isolated file system per agent with merge semantics
-- **Swarm Orchestration** — Parallel multi-agent execution
-- **Timeline State** — Events persisted in SurrealDB
+- **Multi-Agent Routing** — Route specific tasks to specialized agents (e.g., `agy`, `claude`)
+- **Parallel Execution** — Parallel agent orchestration via `gestalt-router`
 - **MCP Client** — Connect to external MCP servers (not a standalone server)
 - **LLM Resilience** — OpenAI + Anthropic adapters with automatic failover
 - **Tool Registry** — 12+ built-in tools (git, shell, file, search, ask_ai, etc.)

--- a/SRC.md
+++ b/SRC.md
@@ -6,7 +6,7 @@
 
 - **Nombre:** gestalt-rust
 - **Tipo:** Rust workspace (5 crates)
-- **Descripción:** Plataforma de orquestación de agentes AI via CLI. VFS + Swarm + Timeline + Tools.
+- **Descripción:** Plataforma de orquestación de agentes AI via CLI. VFS + Multi-agent Routing + Tools.
 - **Tech Stack:** Rust, SurrealDB, tokio
 
 ## Estructura
@@ -15,24 +15,34 @@
 gestalt-rust/
 ├── Cargo.toml              # Workspace (5 crates)
 ├── gestalt_core/           # Core: VFS, auth, LLM, tools, MCP client
-├── gestalt_timeline/        # Orchestrator bin (gestalt)
-├── gestalt_cli/            # REPL bin
-├── gestalt_swarm/          # Swarm coordinator bin
-├── synapse-agentic/        # Tool registry + Hive actor model
+│   └── src/                # Core domain, ports, adapters, application
+├── gestalt_cli/            # CLI binary & REPL
+│   └── src/                # CLI entry point, config, repl
+├── gestalt-router/         # Orchestration Router
+│   └── src/
+│       ├── lib.rs          # Module declarations
+│       ├── run.rs          # Run spec (RunSpec, AgentSpec)
+│       └── run_state.rs    # Run state (RunManifest, AgentState)
+├── gestalt-merge/          # Code integration & merge algorithms
+│   └── src/
+│       └── lib.rs          # Merge logic
+├── synapse-agentic/        # Tool registry + agentic primitives
+│   └── src/
+│       └── lib.rs          # Tool registry and primitives
 ├── skills/                 # OpenClaw skill docs
 ├── docs/                   # Architecture & guides
-└── .gitcore/              # Git-Core planning
+└── .gitcore/               # Git-Core planning docs
 ```
 
 ## Crates
 
 | Crate | Type | Props |
 |-------|------|-------|
-| gestalt_core | lib | 42 .rs files |
-| gestalt_timeline | bin | 37 .rs files |
-| gestalt_cli | bin | 4 .rs files |
-| gestalt_swarm | bin | 1 .rs file |
-| synapse-agentic | lib | tool registry |
+| gestalt_core | lib | 45 .rs files |
+| gestalt_cli | bin | 3 .rs files |
+| gestalt-router | lib | 3 .rs files |
+| gestalt-merge | lib | 1 .rs file |
+| synapse-agentic | lib | 1 .rs file |
 
 ## Estado
 


### PR DESCRIPTION
Updates README, SRC.md, and AGENTS.md to match the active workspace. Specifically, it adds gestalt run examples, lists real files of gestalt-router in the source tree, defines agent design non-negotiables, and removes all references to deprecated gestalt_timeline.

Fixes #308

---
*PR created automatically by Jules for task [10719726717880453437](https://jules.google.com/task/10719726717880453437) started by @iberi22*