### PR TITLE
fix: harden Router — Arc instead of unsafe transmute, safe process group

### DIFF
--- a/gestalt-router/src/agent.rs
+++ b/gestalt-router/src/agent.rs
@@ -3,7 +3,10 @@ use crate::timeline::{Event, EventLog};
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
+use std::process::Command;
 use std::time::{Duration, Instant};
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AgentOutcome {
@@ -84,15 +87,10 @@ impl AgentRunner for SubprocessRunner {
         // Add the task itself as an environment variable or context if needed, but the main thing is sanitizing env
         cmd.env("GESTALT_TASK", task);
 
-        // Configure process group setsid on Unix
+        // Configure process group on Unix (safe, no unsafe)
         #[cfg(unix)]
         {
-            unsafe {
-                cmd.pre_exec(|| {
-                    libc::setsid();
-                    Ok(())
-                });
-            }
+            cmd.process_group(0);
         }
 
         cmd.stdout(std::process::Stdio::piped());

--- a/gestalt-router/src/router.rs
+++ b/gestalt-router/src/router.rs
@@ -14,16 +14,16 @@ use crate::timeline::{Event, EventLog};
 use crate::worktree::WorktreeManager;
 
 pub struct Router {
-    pub worktrees: WorktreeManager,
-    pub runner: Box<dyn AgentRunner>,
-    pub log: Box<dyn EventLog>,
+    pub worktrees: Arc<WorktreeManager>,
+    pub runner: Arc<dyn AgentRunner>,
+    pub log: Arc<dyn EventLog>,
 }
 
 impl Router {
     pub fn new(
-        worktrees: WorktreeManager,
-        runner: Box<dyn AgentRunner>,
-        log: Box<dyn EventLog>,
+        worktrees: Arc<WorktreeManager>,
+        runner: Arc<dyn AgentRunner>,
+        log: Arc<dyn EventLog>,
     ) -> Self {
         Self {
             worktrees,
@@ -152,9 +152,12 @@ impl Router {
         let manifest_mutex = Arc::new(Mutex::new(manifest));
         let mut join_set = JoinSet::new();
 
-        // Cast self to static lifetime safely because we await all spawned tasks
-        // in this method and don't leak them.
-        let static_self: &'static Router = unsafe { std::mem::transmute(self) };
+        // Share Router via Arc for spawned tasks
+        let router = Arc::new(Router {
+            worktrees: self.worktrees.clone(),
+            runner: self.runner.clone(),
+            log: self.log.clone(),
+        });
 
         for agent in spec.agents {
             let sem_clone = semaphore.clone();
@@ -166,6 +169,7 @@ impl Router {
             let run_id_clone = run_id;
             let wt_path = wt_paths.get(&agent_id).cloned().unwrap();
             let timeout = std::time::Duration::from_secs(spec.timeout);
+            let router = router.clone();
 
             join_set.spawn(async move {
                 let _permit = sem_clone.acquire_owned().await.unwrap();
@@ -177,8 +181,8 @@ impl Router {
                         .agent_states
                         .insert(agent_id.clone(), AgentState::Running)
                         .unwrap_or(AgentState::Pending);
-                    static_self.write_manifest_atomically(run_id_clone, &m)?;
-                    let _ = static_self.log.log(Event::AgentStateChanged {
+                    router.write_manifest_atomically(run_id_clone, &m)?;
+                    let _ = router.log.log(Event::AgentStateChanged {
                         run_id: run_id_clone,
                         agent_id: agent_id.clone(),
                         from: old_state,
@@ -187,7 +191,7 @@ impl Router {
                 }
 
                 // Run Agent
-                let mut run_result = static_self
+                let mut run_result = router
                     .runner
                     .run(&agent_spec, &wt_path, &task_desc, timeout)
                     .await?;
@@ -223,8 +227,8 @@ impl Router {
                         .agent_states
                         .insert(agent_id.clone(), final_state)
                         .unwrap_or(AgentState::Running);
-                    static_self.write_manifest_atomically(run_id_clone, &m)?;
-                    let _ = static_self.log.log(Event::AgentStateChanged {
+                    router.write_manifest_atomically(run_id_clone, &m)?;
+                    let _ = router.log.log(Event::AgentStateChanged {
                         run_id: run_id_clone,
                         agent_id: agent_id.clone(),
                         from: old_state,

--- a/gestalt_cli/src/main.rs
+++ b/gestalt_cli/src/main.rs
@@ -972,7 +972,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             };
 
             // 6. Create Router and execute
-            let router = Router::new(worktrees, Box::new(runner), Box::new(log));
+            let router = Router::new(Arc::new(worktrees), Arc::new(runner), Arc::new(log));
             println!("⚙️  Executing run...");
 
             match router.execute(spec).await {


### PR DESCRIPTION
## Changes
1. **Router**: Replaced  with  — tasks hold Arc clones, no soundness hole
2. **SubprocessRunner**: Replaced unsafe  in  with safe  — no fork-safety hazard
3. **CLI**: Updated  call to pass  wrappers

## Safety
- No more unsafe blocks in Router or Agent
- Task-spawning pattern now follows idiomatic Arc-clone approach
- Process group creation is safe and portable

## Validation
- cargo check --workspace: 0 errors
- No functional changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved subprocess termination behavior on Unix systems, helping stop related processes more reliably.
  * Improved reliability when running multiple agent tasks concurrently.

* **Refactor**
  * Updated task execution and state tracking to support safer concurrent operations without changing existing workflow behavior.
  * Preserved manifest updates, event logging, checkpointing, and final state reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->