### PR TITLE
Exclude gestalt_swarm from Cargo workspace and update AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ Welcome! This document outlines the absolute design non-negotiables (reglas inqu
 - **Fail Gracefully:** Never panic or crash due to rate-limiting or service-down events; always capture structured error logs and return a clean failure/timeout agent state.
 
 ### 5. Workspace Crate Exclusion
-- **`gestalt_swarm`** is the only crate excluded from the Cargo workspace members in `Cargo.toml` (prevents compilation/link errors regarding `GroqProvider` or `synapse-agentic`).
+- **`gestalt_swarm`** is excluded from the Cargo workspace members in `Cargo.toml` (resolving compilation/link errors regarding `GroqProvider` or `synapse-agentic`).
 - All other crates (`gestalt_core`, `gestalt_cli`, `gestalt-router`, `gestalt-merge`, `gestalt-state`, `gestalt-ws`, `synapse-agentic`) are active workspace members and compile together.
 
 ---

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1915,22 +1915,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gestalt_swarm"
-version = "1.0.0"
-dependencies = [
- "anyhow",
- "clap",
- "gestalt_core",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "synapse-agentic",
- "tokio",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ members = [
     "gestalt-merge",
     "gestalt-state",
     "gestalt-ws",
-    "gestalt_swarm",
 ]
 resolver = "2"
 


### PR DESCRIPTION
Excluded gestalt_swarm from Cargo.toml workspace members, resolving 41 compilation errors when performing workspace-wide checks/tests. Updated AGENTS.md Section 5 to match and reinforce this exclusion. Verified that cargo check --workspace passes cleanly and active package tests run successfully.

Fixes #452

---
*PR created automatically by Jules for task [17495083703262979196](https://jules.google.com/task/17495083703262979196) started by @iberi22*