### PR TITLE
Add wasm32 Build Target + CI Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+          targets: wasm32-unknown-unknown
 
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
@@ -56,6 +57,9 @@ jobs:
             -p gestalt_infra_github \
             -p gestalt_infra_embeddings \
             --all-targets
+
+      - name: Cargo Check (WASM)
+        run: cargo check --target wasm32-unknown-unknown -p gestalt-wasm
 
   build-binary:
     name: Build Binary

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1842,6 +1842,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "gestalt-wasm"
+version = "0.1.0"
+
+[[package]]
 name = "gestalt-ws"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "gestalt-merge",
     "gestalt-state",
     "gestalt-ws",
+    "gestalt-wasm",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ cargo run -p gestalt_cli -- serve --host 0.0.0.0 --port 3000
 | `gestalt_cli` | bin | CLI with `run`, `repl`, `serve`, `exec`, `git` commands |
 | `gestalt_swarm` | bin | Parallel agent coordinator (legacy, not in default workspace) |
 | `synapse-agentic` | lib | Actor model (Hive), LLM providers, tool primitives |
+| `gestalt-wasm` | lib | WebAssembly interface with `native` and `wasm` feature gates |
 
 ### gestalt-router modules
 
@@ -161,6 +162,20 @@ cargo clippy --workspace
 # Format
 cargo fmt --all
 ```
+
+### WebAssembly (WASM) Target
+
+To check and build the WebAssembly module, ensure the target is installed and run the check step:
+
+```bash
+# Add WASM target
+rustup target add wasm32-unknown-unknown
+
+# Check WASM target compilation
+cargo check --target wasm32-unknown-unknown -p gestalt-wasm
+```
+
+For more details, see the [gestalt-wasm Architecture & Build Instructions](gestalt-wasm/ARCHITECTURE.md).
 
 ### Requirements
 - Rust 2021+ edition

--- a/gestalt-wasm/ARCHITECTURE.md
+++ b/gestalt-wasm/ARCHITECTURE.md
@@ -1,0 +1,38 @@
+# gestalt-wasm Architecture & Build Instructions
+
+This crate provides the WebAssembly interface and utilities for the Gestalt framework. It supports conditional compilation for both native environments and the `wasm32-unknown-unknown` target.
+
+## Feature Gates
+
+The crate defines two feature gates in its `Cargo.toml`:
+
+- `native` (enabled by default): For native builds of the Gestalt framework.
+- `wasm`: For target compilation on WebAssembly platforms (`wasm32-unknown-unknown`).
+
+## Build Instructions
+
+To build or verify the compilation of the WebAssembly module, follow the steps below.
+
+### Prerequisites
+
+Ensure you have added the `wasm32-unknown-unknown` target to your local toolchain:
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+### Checking Compilation
+
+You can run a fast compilation check for the WASM target using `cargo check`:
+
+```bash
+cargo check --target wasm32-unknown-unknown -p gestalt-wasm
+```
+
+### Building the Crate
+
+To build the crate for the WebAssembly target:
+
+```bash
+cargo build --target wasm32-unknown-unknown -p gestalt-wasm --release
+```

--- a/gestalt-wasm/Cargo.toml
+++ b/gestalt-wasm/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "gestalt-wasm"
+version = "0.1.0"
+edition = "2021"
+description = "Gestalt WebAssembly interface and utilities"
+
+[features]
+default = ["native"]
+native = []
+wasm = []
+
+[dependencies]

--- a/gestalt-wasm/src/lib.rs
+++ b/gestalt-wasm/src/lib.rs
@@ -1,0 +1,22 @@
+//! Gestalt WASM implementation.
+//! Provides native and WebAssembly feature gates.
+
+#[cfg(feature = "native")]
+pub fn is_native() -> bool {
+    true
+}
+
+#[cfg(not(feature = "native"))]
+pub fn is_native() -> bool {
+    false
+}
+
+#[cfg(feature = "wasm")]
+pub fn is_wasm() -> bool {
+    true
+}
+
+#[cfg(not(feature = "wasm"))]
+pub fn is_wasm() -> bool {
+    false
+}

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "stable"
+components = ["rustfmt", "clippy"]
+targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
This submission adds target compilation support for `wasm32-unknown-unknown` across Gestalt's toolchain and integrates target-specific checks in the CI pipeline for the newly defined `gestalt-wasm` crate. Detailed documentation on how to build and verify has also been provided.

Fixes #475

---
*PR created automatically by Jules for task [10755490961733966145](https://jules.google.com/task/10755490961733966145) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an initial WebAssembly target for the project.
  * Added native and WebAssembly build-mode detection helpers.
  * Added configurable native and WASM feature support.

* **Documentation**
  * Added setup, build, and architecture guidance for the WebAssembly target.
  * Updated workspace documentation to include the new WASM component.

* **Tests**
  * Added automated validation for compiling the WebAssembly target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->