### PR TITLE
fix(router): replace thread::sleep with tokio::time::sleep in integrate.rs

### DIFF
--- a/gestalt-router/src/integrate.rs
+++ b/gestalt-router/src/integrate.rs
@@ -117,7 +117,7 @@ pub type TestHookFn = Box<dyn FnMut(&mut Vec<(String, String)>)>;
 pub struct CleanSlateRetry;
 
 /// Integration implementation with clean-slate retry mechanism.
-pub fn integrate_branches(
+pub async fn integrate_branches(
     repo_dir: &Path,
     base_sha: &str,
     integration_branch: &str,
@@ -146,7 +146,7 @@ pub fn integrate_branches(
                 {
                     let err = ClassifiedMergeError::Conflict("Merge conflict detected".to_string());
                     if err.is_retryable(&policy) {
-                        std::thread::sleep(policy.backoff);
+                        tokio::time::sleep(policy.backoff).await;
                         continue;
                     }
                 }
@@ -155,7 +155,7 @@ pub fn integrate_branches(
             Err(e) => {
                 let classified = classify_router_error(&e);
                 if classified.is_retryable(&policy) && attempts < policy.max_attempts {
-                    std::thread::sleep(policy.backoff);
+                    tokio::time::sleep(policy.backoff).await;
                     continue;
                 }
                 return Err(e);
@@ -428,8 +428,8 @@ mod tests {
             .unwrap();
     }
 
-    #[test]
-    fn test_conflict_error_clean_slate_retry_succeeds() {
+    #[tokio::test]
+    async fn test_conflict_error_clean_slate_retry_succeeds() {
         let temp = TempDir::new();
         let repo_path = temp.path.clone();
         init_git_repo(&repo_path);
@@ -571,7 +571,7 @@ mod tests {
             ("agent_b".to_string(), sha_b),
         ];
 
-        let result = integrate_branches(&repo_path, &base_sha, "integration", &branches).unwrap();
+        let result = integrate_branches(&repo_path, &base_sha, "integration", &branches).await.unwrap();
 
         // Verify that it successfully completed on retry (no conflicts, got a valid merge sha)
         assert!(

--- a/gestalt-router/src/integrate.rs
+++ b/gestalt-router/src/integrate.rs
@@ -571,7 +571,9 @@ mod tests {
             ("agent_b".to_string(), sha_b),
         ];
 
-        let result = integrate_branches(&repo_path, &base_sha, "integration", &branches).await.unwrap();
+        let result = integrate_branches(&repo_path, &base_sha, "integration", &branches)
+            .await
+            .unwrap();
 
         // Verify that it successfully completed on retry (no conflicts, got a valid merge sha)
         assert!(

--- a/gestalt-router/src/overlap.rs
+++ b/gestalt-router/src/overlap.rs
@@ -397,7 +397,7 @@ pub struct IndependentMergeResult {
 
 /// Integrates branches of successful agents independently, while reporting failed agents separately.
 /// One agent failure does not block the integration/merging of other successful agents.
-pub fn merge_independent_agents(
+pub async fn merge_independent_agents(
     repo_path: &Path,
     base_sha: &str,
     integration_branch: &str,
@@ -433,7 +433,7 @@ pub fn merge_independent_agents(
         base_sha,
         integration_branch,
         &branches_to_merge,
-    )?;
+    ).await?;
 
     let merge_sha = if integrate_res.merge_sha.is_empty() {
         None
@@ -816,8 +816,8 @@ mod tests {
         run_git_test(repo_path, &["checkout", "main"]);
     }
 
-    #[test]
-    fn test_agent_a_fails_agent_b_completes_results_merged() {
+    #[tokio::test]
+    async fn test_agent_a_fails_agent_b_completes_results_merged() {
         let repo_path = create_test_git_repo();
         let base_sha = run_git_test(&repo_path, &["rev-parse", "HEAD"]);
 
@@ -837,7 +837,7 @@ mod tests {
             },
         ];
 
-        let result = merge_independent_agents(&repo_path, &base_sha, "main", &agents).unwrap();
+        let result = merge_independent_agents(&repo_path, &base_sha, "main", &agents).await.unwrap();
 
         // Check B results are merged
         assert!(result.merge_sha.is_some());

--- a/gestalt-router/src/overlap.rs
+++ b/gestalt-router/src/overlap.rs
@@ -433,7 +433,8 @@ pub async fn merge_independent_agents(
         base_sha,
         integration_branch,
         &branches_to_merge,
-    ).await?;
+    )
+    .await?;
 
     let merge_sha = if integrate_res.merge_sha.is_empty() {
         None
@@ -837,7 +838,9 @@ mod tests {
             },
         ];
 
-        let result = merge_independent_agents(&repo_path, &base_sha, "main", &agents).await.unwrap();
+        let result = merge_independent_agents(&repo_path, &base_sha, "main", &agents)
+            .await
+            .unwrap();
 
         // Check B results are merged
         assert!(result.merge_sha.is_some());

--- a/gestalt-router/tests/integration_test.rs
+++ b/gestalt-router/tests/integration_test.rs
@@ -355,7 +355,9 @@ async fn test_integrate_branches_success_and_conflict() {
         ("agent_b".to_string(), sha_b.clone()),
     ];
 
-    let result = integrate_branches(&repo_path, &base_sha, "integration", &branches).await.unwrap();
+    let result = integrate_branches(&repo_path, &base_sha, "integration", &branches)
+        .await
+        .unwrap();
     assert!(
         !result.merge_sha.is_empty(),
         "Should produce a merge SHA, but got: {:?}",

--- a/gestalt-router/tests/integration_test.rs
+++ b/gestalt-router/tests/integration_test.rs
@@ -271,8 +271,8 @@ fn test_run_report_with_agents_and_conflicts() {
     assert!(report.success);
 }
 
-#[test]
-fn test_integrate_branches_success_and_conflict() {
+#[tokio::test]
+async fn test_integrate_branches_success_and_conflict() {
     // 1. Initialize git repo
     let dir = init_test_repo();
     let repo_path = dir.path().to_path_buf();
@@ -355,7 +355,7 @@ fn test_integrate_branches_success_and_conflict() {
         ("agent_b".to_string(), sha_b.clone()),
     ];
 
-    let result = integrate_branches(&repo_path, &base_sha, "integration", &branches).unwrap();
+    let result = integrate_branches(&repo_path, &base_sha, "integration", &branches).await.unwrap();
     assert!(
         !result.merge_sha.is_empty(),
         "Should produce a merge SHA, but got: {:?}",
@@ -444,6 +444,7 @@ fn test_integrate_branches_success_and_conflict() {
         "integration_conflict",
         &binary_branches,
     )
+    .await
     .unwrap();
     assert!(
         result_conflict.merge_sha.is_empty(),

--- a/gestalt-router/tests/router_tests.rs
+++ b/gestalt-router/tests/router_tests.rs
@@ -777,8 +777,8 @@ fn test_mergeresult_variants() {
     }
 }
 
-#[test]
-fn test_integrate_branches_no_conflicts() {
+#[tokio::test]
+async fn test_integrate_branches_no_conflicts() {
     let tmp = TempDir::new("gestalt-integrate-clean");
     let dir = &tmp.path;
     let base_sha = setup_git_repo(dir);
@@ -801,7 +801,7 @@ fn test_integrate_branches_no_conflicts() {
         ("agent_b".to_string(), "branch_agent_b".to_string()),
     ];
 
-    let result = integrate_branches(dir, &base_sha, "integration/main", &branches).unwrap();
+    let result = integrate_branches(dir, &base_sha, "integration/main", &branches).await.unwrap();
     assert!(!result.merge_sha.is_empty(), "expected a merge SHA");
     assert_eq!(result.merged_branches.len(), 2);
     assert!(

--- a/gestalt-router/tests/router_tests.rs
+++ b/gestalt-router/tests/router_tests.rs
@@ -801,7 +801,9 @@ async fn test_integrate_branches_no_conflicts() {
         ("agent_b".to_string(), "branch_agent_b".to_string()),
     ];
 
-    let result = integrate_branches(dir, &base_sha, "integration/main", &branches).await.unwrap();
+    let result = integrate_branches(dir, &base_sha, "integration/main", &branches)
+        .await
+        .unwrap();
     assert!(!result.merge_sha.is_empty(), "expected a merge SHA");
     assert_eq!(result.merged_branches.len(), 2);
     assert!(


### PR DESCRIPTION
Migrates `std::thread::sleep` to non-blocking `tokio::time::sleep(...).await` inside the async-adjacent `integrate_branches` function in `gestalt-router` to avoid blocking tokio threads. Also propagates the async changes up to its caller `merge_independent_agents` in `gestalt-router/src/overlap.rs` and relevant unit and integration test suites.

Fixes #483

---
*PR created automatically by Jules for task [929022861679689994](https://jules.google.com/task/929022861679689994) started by @iberi22*