### PR TITLE
feat(search): add score normalization and dedup to hybrid search

### DIFF
--- a/gestalt-search/src/hybrid.rs
+++ b/gestalt-search/src/hybrid.rs
@@ -34,6 +34,8 @@ pub struct HybridSearchEngine {
     local: Arc<dyn LocalSearchEngine>,
     remote: Option<XavierClient>,
     mode: SearchMode,
+    local_weight: f64,
+    remote_weight: f64,
 }
 
 impl HybridSearchEngine {
@@ -43,15 +45,21 @@ impl HybridSearchEngine {
     /// * `local` — The local BM25 search engine (Tantivy).
     /// * `remote` — Optional Xavier HTTP client.
     /// * `mode` — Search mode preference.
+    /// * `local_weight` — Relative weight for local BM25 results.
+    /// * `remote_weight` — Relative weight for remote Xavier vector results.
     pub fn new(
         local: Arc<dyn LocalSearchEngine>,
         remote: Option<XavierClient>,
         mode: SearchMode,
+        local_weight: f64,
+        remote_weight: f64,
     ) -> Self {
         Self {
             local,
             remote,
             mode,
+            local_weight,
+            remote_weight,
         }
     }
 
@@ -145,6 +153,37 @@ impl HybridSearchEngine {
             results
         }
     }
+
+    /// Search both local and remote, normalize their scores, apply weights,
+    /// and merge/deduplicate them into a single sorted result set.
+    pub async fn search_hybrid(
+        &self,
+        query: &str,
+        kind: Option<&str>,
+        limit: usize,
+    ) -> anyhow::Result<Vec<SearchResult>> {
+        let local_results = self.local.search_filtered(query, kind, limit).await?;
+        let remote_results = self.search_remote_filtered(query, kind, limit).await;
+
+        let normalized_local = normalize_scores(&local_results);
+        let normalized_remote = normalize_scores(&remote_results);
+
+        let mut weighted_local = normalized_local;
+        for r in &mut weighted_local {
+            r.score *= self.local_weight;
+        }
+
+        let mut weighted_remote = normalized_remote;
+        for r in &mut weighted_remote {
+            r.score *= self.remote_weight;
+        }
+
+        let merged = merge_and_dedup(weighted_local, weighted_remote);
+        let mut results = merged;
+        results.truncate(limit);
+
+        Ok(results)
+    }
 }
 
 #[async_trait]
@@ -180,16 +219,7 @@ impl LocalSearchEngine for HybridSearchEngine {
                 Ok(self.search_remote_filtered(query, kind, limit).await)
             },
             SearchMode::Hybrid => {
-                // Try local first
-                let local_results = self.local.search_filtered(query, kind, limit).await?;
-
-                if !local_results.is_empty() {
-                    return Ok(local_results);
-                }
-
-                // Fall back to remote
-                info!("Local search returned 0 results, falling back to Xavier");
-                Ok(self.search_remote_filtered(query, kind, limit).await)
+                self.search_hybrid(query, kind, limit).await
             },
         }
     }
@@ -207,6 +237,64 @@ impl LocalSearchEngine for HybridSearchEngine {
     }
 }
 
+/// Normalizes a slice of SearchResults' scores into the range [0, 1] using min-max normalization.
+/// If all scores are equal, maps them to 1.0.
+fn normalize_scores(results: &[SearchResult]) -> Vec<SearchResult> {
+    if results.is_empty() {
+        return Vec::new();
+    }
+    let mut min_score = f64::MAX;
+    let mut max_score = f64::MIN;
+    for r in results {
+        if r.score < min_score {
+            min_score = r.score;
+        }
+        if r.score > max_score {
+            max_score = r.score;
+        }
+    }
+
+    let range = max_score - min_score;
+    results
+        .iter()
+        .map(|r| {
+            let normalized_score = if range.abs() < 1e-9 {
+                1.0
+            } else {
+                (r.score - min_score) / range
+            };
+            SearchResult {
+                score: normalized_score,
+                ..r.clone()
+            }
+        })
+        .collect()
+}
+
+/// Merges two vectors of SearchResults, deduplicating by document ID while keeping
+/// the result with the highest score. The merged vector is sorted descending by score.
+fn merge_and_dedup(local: Vec<SearchResult>, remote: Vec<SearchResult>) -> Vec<SearchResult> {
+    let mut merged: std::collections::HashMap<String, SearchResult> = std::collections::HashMap::new();
+
+    for r in local {
+        merged.insert(r.id.clone(), r);
+    }
+
+    for r in remote {
+        if let Some(existing) = merged.get_mut(&r.id) {
+            if r.score > existing.score {
+                *existing = r;
+            }
+        } else {
+            merged.insert(r.id.clone(), r);
+        }
+    }
+
+    let mut final_results: Vec<SearchResult> = merged.into_values().collect();
+    final_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    final_results
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -222,7 +310,7 @@ mod tests {
     #[tokio::test]
     async fn test_local_mode() {
         let local = create_local_engine();
-        let hybrid = HybridSearchEngine::new(local.clone(), None, SearchMode::Local);
+        let hybrid = HybridSearchEngine::new(local.clone(), None, SearchMode::Local, 1.0, 1.0);
 
         local
             .index_document("1", "test.md", "Rust programming", "code")
@@ -236,7 +324,7 @@ mod tests {
     #[tokio::test]
     async fn test_remote_fallback_empty_local() {
         let local = create_local_engine();
-        let hybrid = HybridSearchEngine::new(local.clone(), None, SearchMode::Hybrid);
+        let hybrid = HybridSearchEngine::new(local.clone(), None, SearchMode::Hybrid, 1.0, 1.0);
 
         // No documents in local, but no remote either — should return empty
         let results = hybrid.search("anything", 10).await.unwrap();
@@ -246,7 +334,7 @@ mod tests {
     #[tokio::test]
     async fn test_local_has_results_no_fallback() {
         let local = create_local_engine();
-        let hybrid = HybridSearchEngine::new(local.clone(), None, SearchMode::Hybrid);
+        let hybrid = HybridSearchEngine::new(local.clone(), None, SearchMode::Hybrid, 1.0, 1.0);
 
         local
             .index_document("1", "doc.md", "BM25 search engine", "code")
@@ -257,5 +345,197 @@ mod tests {
         let results = hybrid.search("BM25", 10).await.unwrap();
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].id, "1");
+    }
+
+    #[test]
+    fn test_score_normalization() {
+        // Empty
+        let empty_results = normalize_scores(&[]);
+        assert!(empty_results.is_empty());
+
+        // Single result
+        let single = vec![SearchResult {
+            id: "1".to_string(),
+            path: "a.md".to_string(),
+            content: "hello".to_string(),
+            snippet: "hello".to_string(),
+            score: 42.0,
+        }];
+        let normalized_single = normalize_scores(&single);
+        assert_eq!(normalized_single.len(), 1);
+        assert_eq!(normalized_single[0].score, 1.0);
+
+        // Identical scores
+        let identical = vec![
+            SearchResult {
+                id: "1".to_string(),
+                path: "a.md".to_string(),
+                content: "hello".to_string(),
+                snippet: "hello".to_string(),
+                score: 5.0,
+            },
+            SearchResult {
+                id: "2".to_string(),
+                path: "b.md".to_string(),
+                content: "world".to_string(),
+                snippet: "world".to_string(),
+                score: 5.0,
+            },
+        ];
+        let normalized_identical = normalize_scores(&identical);
+        assert_eq!(normalized_identical.len(), 2);
+        assert_eq!(normalized_identical[0].score, 1.0);
+        assert_eq!(normalized_identical[1].score, 1.0);
+
+        // Different scores
+        let different = vec![
+            SearchResult {
+                id: "1".to_string(),
+                path: "a.md".to_string(),
+                content: "hello".to_string(),
+                snippet: "hello".to_string(),
+                score: 2.0,
+            },
+            SearchResult {
+                id: "2".to_string(),
+                path: "b.md".to_string(),
+                content: "world".to_string(),
+                snippet: "world".to_string(),
+                score: 6.0,
+            },
+            SearchResult {
+                id: "3".to_string(),
+                path: "c.md".to_string(),
+                content: "rust".to_string(),
+                snippet: "rust".to_string(),
+                score: 10.0,
+            },
+        ];
+        let normalized_different = normalize_scores(&different);
+        assert_eq!(normalized_different.len(), 3);
+        // Score 2.0 -> min -> 0.0
+        // Score 10.0 -> max -> 1.0
+        // Score 6.0 -> (6 - 2) / (10 - 2) = 4 / 8 = 0.5
+        assert!((normalized_different[0].score - 0.0).abs() < 1e-9);
+        assert!((normalized_different[1].score - 0.5).abs() < 1e-9);
+        assert!((normalized_different[2].score - 1.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_merge_and_deduplication() {
+        let local = vec![
+            SearchResult {
+                id: "1".to_string(),
+                path: "a.md".to_string(),
+                content: "hello".to_string(),
+                snippet: "hello".to_string(),
+                score: 0.8,
+            },
+            SearchResult {
+                id: "2".to_string(),
+                path: "b.md".to_string(),
+                content: "world".to_string(),
+                snippet: "world".to_string(),
+                score: 0.3,
+            },
+        ];
+
+        let remote = vec![
+            SearchResult {
+                id: "2".to_string(),
+                path: "b.md".to_string(),
+                content: "world".to_string(),
+                snippet: "world".to_string(),
+                score: 0.9, // Higher score than local
+            },
+            SearchResult {
+                id: "3".to_string(),
+                path: "c.md".to_string(),
+                content: "rust".to_string(),
+                snippet: "rust".to_string(),
+                score: 0.5,
+            },
+        ];
+
+        let merged = merge_and_dedup(local, remote);
+        // Expecting 3 results: id 2 (score 0.9), id 1 (score 0.8), id 3 (score 0.5)
+        assert_eq!(merged.len(), 3);
+        assert_eq!(merged[0].id, "2");
+        assert_eq!(merged[0].score, 0.9);
+        assert_eq!(merged[1].id, "1");
+        assert_eq!(merged[1].score, 0.8);
+        assert_eq!(merged[2].id, "3");
+        assert_eq!(merged[2].score, 0.5);
+    }
+
+    struct MockLocalSearchEngine {
+        results: Vec<SearchResult>,
+    }
+
+    #[async_trait]
+    impl LocalSearchEngine for MockLocalSearchEngine {
+        async fn index_document(&self, _id: &str, _path: &str, _content: &str, _kind: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn search(&self, _query: &str, _limit: usize) -> anyhow::Result<Vec<SearchResult>> {
+            Ok(self.results.clone())
+        }
+        async fn search_filtered(&self, _query: &str, _kind: Option<&str>, _limit: usize) -> anyhow::Result<Vec<SearchResult>> {
+            Ok(self.results.clone())
+        }
+        async fn delete_document(&self, _id: &str) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn clear(&self) -> anyhow::Result<()> {
+            Ok(())
+        }
+        async fn doc_count(&self) -> anyhow::Result<usize> {
+            Ok(self.results.len())
+        }
+    }
+
+    #[tokio::test]
+    async fn test_weighted_hybrid_search() {
+        let mock_local = Arc::new(MockLocalSearchEngine {
+            results: vec![
+                SearchResult {
+                    id: "1".to_string(),
+                    path: "a.md".to_string(),
+                    content: "hello".to_string(),
+                    snippet: "hello".to_string(),
+                    score: 2.0,
+                },
+                SearchResult {
+                    id: "2".to_string(),
+                    path: "b.md".to_string(),
+                    content: "world".to_string(),
+                    snippet: "world".to_string(),
+                    score: 10.0,
+                },
+            ],
+        });
+
+        // Set weights: local_weight = 0.5, remote_weight = 0.8
+        let hybrid = HybridSearchEngine::new(mock_local, None, SearchMode::Hybrid, 0.5, 0.8);
+
+        // Let's search
+        // We expect local search to return 2 results with different scores.
+        // Under SearchMode::Hybrid, search_hybrid is called.
+        // Since remote is None, remote results are empty.
+        // Local results are normalized (lowest -> 0.0, highest -> 1.0).
+        // Then multiplied by local_weight (0.5), yielding 0.0 and 0.5.
+        let results = hybrid.search("Rust", 10).await.unwrap();
+
+        // Let's assert that we have exactly 2 results
+        assert_eq!(results.len(), 2);
+
+        // Since results are sorted descending, the highest score is first.
+        // It should have score 0.5 (1.0 * local_weight).
+        assert_eq!(results[0].id, "2");
+        assert!((results[0].score - 0.5).abs() < 0.001);
+
+        // The lowest score is last, it should have score 0.0 (0.0 * local_weight).
+        assert_eq!(results[1].id, "1");
+        assert!((results[1].score - 0.0).abs() < 0.001);
     }
 }

--- a/gestalt-search/src/hybrid.rs
+++ b/gestalt-search/src/hybrid.rs
@@ -218,9 +218,7 @@ impl LocalSearchEngine for HybridSearchEngine {
                 // Remote only
                 Ok(self.search_remote_filtered(query, kind, limit).await)
             },
-            SearchMode::Hybrid => {
-                self.search_hybrid(query, kind, limit).await
-            },
+            SearchMode::Hybrid => self.search_hybrid(query, kind, limit).await,
         }
     }
 
@@ -274,7 +272,8 @@ fn normalize_scores(results: &[SearchResult]) -> Vec<SearchResult> {
 /// Merges two vectors of SearchResults, deduplicating by document ID while keeping
 /// the result with the highest score. The merged vector is sorted descending by score.
 fn merge_and_dedup(local: Vec<SearchResult>, remote: Vec<SearchResult>) -> Vec<SearchResult> {
-    let mut merged: std::collections::HashMap<String, SearchResult> = std::collections::HashMap::new();
+    let mut merged: std::collections::HashMap<String, SearchResult> =
+        std::collections::HashMap::new();
 
     for r in local {
         merged.insert(r.id.clone(), r);
@@ -291,7 +290,11 @@ fn merge_and_dedup(local: Vec<SearchResult>, remote: Vec<SearchResult>) -> Vec<S
     }
 
     let mut final_results: Vec<SearchResult> = merged.into_values().collect();
-    final_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    final_results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     final_results
 }
 
@@ -474,13 +477,24 @@ mod tests {
 
     #[async_trait]
     impl LocalSearchEngine for MockLocalSearchEngine {
-        async fn index_document(&self, _id: &str, _path: &str, _content: &str, _kind: &str) -> anyhow::Result<()> {
+        async fn index_document(
+            &self,
+            _id: &str,
+            _path: &str,
+            _content: &str,
+            _kind: &str,
+        ) -> anyhow::Result<()> {
             Ok(())
         }
         async fn search(&self, _query: &str, _limit: usize) -> anyhow::Result<Vec<SearchResult>> {
             Ok(self.results.clone())
         }
-        async fn search_filtered(&self, _query: &str, _kind: Option<&str>, _limit: usize) -> anyhow::Result<Vec<SearchResult>> {
+        async fn search_filtered(
+            &self,
+            _query: &str,
+            _kind: Option<&str>,
+            _limit: usize,
+        ) -> anyhow::Result<Vec<SearchResult>> {
             Ok(self.results.clone())
         }
         async fn delete_document(&self, _id: &str) -> anyhow::Result<()> {


### PR DESCRIPTION
Add score normalization, deduplication, and configurable weights to the HybridSearchEngine. Extends the unit test suite with 3 comprehensive new tests.

Fixes #489

---
*PR created automatically by Jules for task [3024320955630941060](https://jules.google.com/task/3024320955630941060) started by @iberi22*