### PR TITLE
FEAT-GT-010: LLM provider resilience layer: automatic failover, clean Timeout/Crashed states

### DIFF
--- a/gestalt_core/src/ports/outbound/llm_resilience.rs
+++ b/gestalt_core/src/ports/outbound/llm_resilience.rs
@@ -86,7 +86,11 @@ impl LlmResilience {
 
         for (provider_idx, provider) in providers.enumerate() {
             let mut backoff = self.initial_backoff;
-            let provider_label = if provider_idx == 0 { "primary" } else { "fallback" };
+            let provider_label = if provider_idx == 0 {
+                "primary"
+            } else {
+                "fallback"
+            };
 
             for attempt in 1..=self.max_retries {
                 tracing::info!(
@@ -108,7 +112,7 @@ impl LlmResilience {
                             provider.name()
                         );
                         return Ok(text);
-                    }
+                    },
                     Ok(Err(e)) => {
                         let err_msg = e.to_string();
                         tracing::warn!(
@@ -123,7 +127,7 @@ impl LlmResilience {
                             provider.name(),
                             err_msg
                         )));
-                    }
+                    },
                     Err(_) => {
                         tracing::warn!(
                             "Provider '{}' call timed out after {:?}. Attempt {}/{}",
@@ -137,7 +141,7 @@ impl LlmResilience {
                             provider.name(),
                             self.timeout
                         )));
-                    }
+                    },
                 }
 
                 // If not the last attempt, sleep with backoff

--- a/gestalt_core/src/ports/outbound/llm_resilience.rs
+++ b/gestalt_core/src/ports/outbound/llm_resilience.rs
@@ -1,0 +1,164 @@
+//! 🛡️ LLM Provider Resilience Layer
+//!
+//! Provides automatic failover, retries with exponential backoff, and timeouts for
+//! LLM generation requests. Never panics on failure; instead, it returns structured
+//! errors that map directly to `Timeout` or `Crashed` agent states.
+
+use std::sync::Arc;
+use std::time::Duration;
+use synapse_agentic::providers::LLMProvider;
+use thiserror::Error;
+
+/// Structured error representing the failure mode of the resilient LLM execution.
+/// Maps cleanly to `AgentState::Timeout` or `AgentState::Crashed`.
+#[derive(Debug, Error, Clone)]
+pub enum LlmResilienceError {
+    /// The request or individual retries timed out.
+    #[error("LLM execution timed out: {0}")]
+    Timeout(String),
+
+    /// The request failed due to provider crashing, outages, rate limits, or all failovers failing.
+    #[error("LLM execution crashed/failed: {0}")]
+    Crashed(String),
+}
+
+/// A centralized resilience layer configuration for LLM calls.
+/// Coordinates primary provider execution, retries with exponential backoff, and automatic
+/// fallback routing to alternate providers if needed.
+#[derive(Clone)]
+pub struct LlmResilience {
+    /// The primary LLM provider to attempt first.
+    pub primary: Arc<dyn LLMProvider>,
+    /// Fallback LLM providers to try in order if the primary provider fails.
+    pub fallbacks: Vec<Arc<dyn LLMProvider>>,
+    /// Maximum number of retries per provider.
+    pub max_retries: usize,
+    /// Initial duration to wait before the first retry (exponentially doubled after each retry).
+    pub initial_backoff: Duration,
+    /// Timeout duration enforced on each individual provider call.
+    pub timeout: Duration,
+}
+
+impl std::fmt::Debug for LlmResilience {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LlmResilience")
+            .field("primary", &self.primary.name())
+            .field(
+                "fallbacks",
+                &self.fallbacks.iter().map(|f| f.name()).collect::<Vec<_>>(),
+            )
+            .field("max_retries", &self.max_retries)
+            .field("initial_backoff", &self.initial_backoff)
+            .field("timeout", &self.timeout)
+            .finish()
+    }
+}
+
+impl LlmResilience {
+    /// Creates a new resilience manager.
+    pub fn new(
+        primary: Arc<dyn LLMProvider>,
+        fallbacks: Vec<Arc<dyn LLMProvider>>,
+        max_retries: usize,
+        initial_backoff: Duration,
+        timeout: Duration,
+    ) -> Self {
+        Self {
+            primary,
+            fallbacks,
+            max_retries,
+            initial_backoff,
+            timeout,
+        }
+    }
+
+    /// Executes the prompt using the configured resilience strategy:
+    /// - Starts with the primary provider.
+    /// - Enforces timeouts on individual calls.
+    /// - Retries failures with exponential backoff.
+    /// - Gracefully falls back to configured secondary providers if the primary (after retries) continues to fail.
+    /// - Returns a structured `LlmResilienceError` indicating `Timeout` or `Crashed` states if all options are exhausted.
+    pub async fn call_with_failover(&self, prompt: &str) -> Result<String, LlmResilienceError> {
+        let mut last_err = None;
+
+        // Sequence: Primary provider, followed by each fallback provider in order.
+        let providers = std::iter::once(&self.primary).chain(self.fallbacks.iter());
+
+        for (provider_idx, provider) in providers.enumerate() {
+            let mut backoff = self.initial_backoff;
+            let provider_label = if provider_idx == 0 { "primary" } else { "fallback" };
+
+            for attempt in 1..=self.max_retries {
+                tracing::info!(
+                    "Attempt {}/{} for {} provider '{}' (index {})",
+                    attempt,
+                    self.max_retries,
+                    provider_label,
+                    provider.name(),
+                    provider_idx
+                );
+
+                let result = tokio::time::timeout(self.timeout, provider.generate(prompt)).await;
+
+                match result {
+                    Ok(Ok(text)) => {
+                        tracing::info!(
+                            "Successfully generated content on attempt {} with provider '{}'",
+                            attempt,
+                            provider.name()
+                        );
+                        return Ok(text);
+                    }
+                    Ok(Err(e)) => {
+                        let err_msg = e.to_string();
+                        tracing::warn!(
+                            "Provider '{}' returned error: {}. Attempt {}/{}",
+                            provider.name(),
+                            err_msg,
+                            attempt,
+                            self.max_retries
+                        );
+                        last_err = Some(LlmResilienceError::Crashed(format!(
+                            "Provider '{}' crashed: {}",
+                            provider.name(),
+                            err_msg
+                        )));
+                    }
+                    Err(_) => {
+                        tracing::warn!(
+                            "Provider '{}' call timed out after {:?}. Attempt {}/{}",
+                            provider.name(),
+                            self.timeout,
+                            attempt,
+                            self.max_retries
+                        );
+                        last_err = Some(LlmResilienceError::Timeout(format!(
+                            "Provider '{}' timed out after {:?}",
+                            provider.name(),
+                            self.timeout
+                        )));
+                    }
+                }
+
+                // If not the last attempt, sleep with backoff
+                if attempt < self.max_retries {
+                    tracing::info!("Waiting {:?} before next retry...", backoff);
+                    tokio::time::sleep(backoff).await;
+                    backoff *= 2;
+                }
+            }
+
+            tracing::warn!(
+                "All {} retries exhausted for {} provider '{}'",
+                self.max_retries,
+                provider_label,
+                provider.name()
+            );
+        }
+
+        // If we made it here, every provider and retry attempt failed. Return the structured error.
+        Err(last_err.unwrap_or_else(|| {
+            LlmResilienceError::Crashed("All configured providers failed to execute.".to_string())
+        }))
+    }
+}

--- a/gestalt_core/src/ports/outbound/mod.rs
+++ b/gestalt_core/src/ports/outbound/mod.rs
@@ -1,3 +1,4 @@
+pub mod llm_resilience;
 pub mod mcp_client;
 pub mod repo_manager;
 pub mod search;

--- a/gestalt_core/tests/llm_resilience_test.rs
+++ b/gestalt_core/tests/llm_resilience_test.rs
@@ -1,8 +1,8 @@
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Duration;
 use async_trait::async_trait;
 use gestalt_core::ports::outbound::llm_resilience::{LlmResilience, LlmResilienceError};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
 use synapse_agentic::providers::LLMProvider;
 
 struct MockProvider {
@@ -86,7 +86,11 @@ async fn test_rate_limit_retry_and_crashed_error() {
     let primary = Arc::new(MockProvider {
         name: "Rate_Limited_Provider".to_string(),
         call_count: primary_calls.clone(),
-        behavior: Arc::new(|_| Err(anyhow::anyhow!("Rate limit exceeded: 429 Too Many Requests"))),
+        behavior: Arc::new(|_| {
+            Err(anyhow::anyhow!(
+                "Rate limit exceeded: 429 Too Many Requests"
+            ))
+        }),
         delay: None,
     });
 

--- a/gestalt_core/tests/llm_resilience_test.rs
+++ b/gestalt_core/tests/llm_resilience_test.rs
@@ -1,0 +1,179 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
+use async_trait::async_trait;
+use gestalt_core::ports::outbound::llm_resilience::{LlmResilience, LlmResilienceError};
+use synapse_agentic::providers::LLMProvider;
+
+struct MockProvider {
+    name: String,
+    call_count: Arc<AtomicUsize>,
+    behavior: Arc<dyn Fn(usize) -> anyhow::Result<String> + Send + Sync>,
+    delay: Option<Duration>,
+}
+
+impl std::fmt::Debug for MockProvider {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MockProvider")
+            .field("name", &self.name)
+            .field("call_count", &self.call_count)
+            .field("delay", &self.delay)
+            .finish()
+    }
+}
+
+#[async_trait]
+impl LLMProvider for MockProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn cost_per_1k_tokens(&self) -> f64 {
+        0.0
+    }
+
+    async fn generate(&self, _prompt: &str) -> anyhow::Result<String> {
+        self.call_count.fetch_add(1, Ordering::SeqCst);
+        if let Some(delay) = self.delay {
+            tokio::time::sleep(delay).await;
+        }
+        let current_count = self.call_count.load(Ordering::SeqCst);
+        (self.behavior)(current_count)
+    }
+}
+
+/// Test Scenario 1: Primary provider returns error → fallback provider called.
+#[tokio::test]
+async fn test_primary_down_fallback_used() {
+    let primary_calls = Arc::new(AtomicUsize::new(0));
+    let fallback_calls = Arc::new(AtomicUsize::new(0));
+
+    let primary = Arc::new(MockProvider {
+        name: "Primary_Provider".to_string(),
+        call_count: primary_calls.clone(),
+        behavior: Arc::new(|_| Err(anyhow::anyhow!("Service Unavailable"))),
+        delay: None,
+    });
+
+    let fallback = Arc::new(MockProvider {
+        name: "Fallback_Provider".to_string(),
+        call_count: fallback_calls.clone(),
+        behavior: Arc::new(|_| Ok("Hello from Fallback!".to_string())),
+        delay: None,
+    });
+
+    let resilience = LlmResilience::new(
+        primary.clone(),
+        vec![fallback.clone()],
+        1, // 1 attempt, no retry
+        Duration::from_millis(1),
+        Duration::from_secs(1),
+    );
+
+    let result = resilience.call_with_failover("test prompt").await;
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "Hello from Fallback!");
+    assert_eq!(primary_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(fallback_calls.load(Ordering::SeqCst), 1);
+}
+
+/// Test Scenario 2: Rate limit error triggers backoff retries, then still fails, returning a clean structured Crashed error.
+#[tokio::test]
+async fn test_rate_limit_retry_and_crashed_error() {
+    let primary_calls = Arc::new(AtomicUsize::new(0));
+
+    let primary = Arc::new(MockProvider {
+        name: "Rate_Limited_Provider".to_string(),
+        call_count: primary_calls.clone(),
+        behavior: Arc::new(|_| Err(anyhow::anyhow!("Rate limit exceeded: 429 Too Many Requests"))),
+        delay: None,
+    });
+
+    let resilience = LlmResilience::new(
+        primary.clone(),
+        vec![],
+        3, // 3 attempts
+        Duration::from_millis(2),
+        Duration::from_secs(1),
+    );
+
+    let result = resilience.call_with_failover("test prompt").await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, LlmResilienceError::Crashed(_)),
+        "Expected Crashed error, got: {:?}",
+        err
+    );
+    assert!(err.to_string().contains("Rate limit exceeded"));
+    assert_eq!(primary_calls.load(Ordering::SeqCst), 3);
+}
+
+/// Test Scenario 3: Timeout error on providers, returning a clean structured Timeout error.
+#[tokio::test]
+async fn test_timeout_to_timeout_error() {
+    let primary_calls = Arc::new(AtomicUsize::new(0));
+
+    let primary = Arc::new(MockProvider {
+        name: "Slow_Provider".to_string(),
+        call_count: primary_calls.clone(),
+        behavior: Arc::new(|_| Ok("Too late...".to_string())),
+        // Sleep longer than timeout
+        delay: Some(Duration::from_millis(100)),
+    });
+
+    let resilience = LlmResilience::new(
+        primary.clone(),
+        vec![],
+        2, // 2 attempts
+        Duration::from_millis(2),
+        Duration::from_millis(15), // enforce 15ms timeout
+    );
+
+    let result = resilience.call_with_failover("test prompt").await;
+
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    assert!(
+        matches!(err, LlmResilienceError::Timeout(_)),
+        "Expected Timeout error, got: {:?}",
+        err
+    );
+    assert!(err.to_string().contains("timed out after"));
+    assert_eq!(primary_calls.load(Ordering::SeqCst), 2);
+}
+
+/// Test Scenario 4: Primary provider fails on first attempt, but succeeds on the second attempt.
+#[tokio::test]
+async fn test_retry_success_on_second_attempt() {
+    let primary_calls = Arc::new(AtomicUsize::new(0));
+
+    let primary = Arc::new(MockProvider {
+        name: "Flaky_Provider".to_string(),
+        call_count: primary_calls.clone(),
+        behavior: Arc::new(|count| {
+            if count == 1 {
+                Err(anyhow::anyhow!("First call fails transiently"))
+            } else {
+                Ok("Success on second try!".to_string())
+            }
+        }),
+        delay: None,
+    });
+
+    let resilience = LlmResilience::new(
+        primary.clone(),
+        vec![],
+        3, // up to 3 attempts
+        Duration::from_millis(2),
+        Duration::from_secs(1),
+    );
+
+    let result = resilience.call_with_failover("test prompt").await;
+
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), "Success on second try!");
+    assert_eq!(primary_calls.load(Ordering::SeqCst), 2);
+}


### PR DESCRIPTION
Implemented a robust LLM provider resilience layer (`LlmResilience`) under `gestalt_core` to handle automated retries (with exponential backoff), custom timeouts, and primary-to-fallback multi-provider routing. Added comprehensive unit tests under `gestalt_core/tests/llm_resilience_test.rs` to verify rate-limit retries, timeout propagation, and failover behavior using injected thread-safe mock providers.

Fixes #509

---
*PR created automatically by Jules for task [6222269432494166433](https://jules.google.com/task/6222269432494166433) started by @iberi22*