### PR TITLE
feat(observe): implement merge-safe hook and settings injectors (FEAT-GT-040)

### DIFF
--- a/gestalt_cli/src/observe/assets/gestalt-observe-hook.sh
+++ b/gestalt_cli/src/observe/assets/gestalt-observe-hook.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Gestalt Observation Hook
+# Does POST to http://127.0.0.1:8081/api/event with 10s timeout, fail-open, exit 0
+
+AGENT="${1:-unknown-agent}"
+EVENT_TYPE="${2:-run_started}"
+SUMMARY="${3:-Agent execution event}"
+
+# Fail-open POST using curl with --max-time 10 and silent failure
+if command -v curl >/dev/null 2>&1; then
+  curl -s -X POST \
+    -H "Content-Type: application/json" \
+    -d "{\"agent\":\"$AGENT\",\"event_type\":\"$EVENT_TYPE\",\"summary\":\"$SUMMARY\"}" \
+    --max-time 10 \
+    http://127.0.0.1:8081/api/event >/dev/null 2>&1 || :
+fi
+
+exit 0

--- a/gestalt_cli/src/observe/assets/gestalt-observe-status.js
+++ b/gestalt_cli/src/observe/assets/gestalt-observe-status.js
@@ -1,0 +1,40 @@
+// Opencode Plugin template for Gestalt Observe Status
+// Automatically reports event status via universal event bus
+
+(function() {
+  const url = 'http://127.0.0.1:8081/api/event';
+  const payload = {
+    agent: 'opencode-plugin',
+    event_type: 'agent_state',
+    summary: 'Opencode agent status update',
+    state: 'Running',
+    ts: new Date().toISOString()
+  };
+
+  if (typeof fetch === 'function') {
+    let signal = null;
+    let timeoutId = null;
+
+    if (typeof AbortController === 'function') {
+      const controller = new AbortController();
+      signal = controller.signal;
+      timeoutId = setTimeout(() => controller.abort(), 10000); // 10s timeout
+    }
+
+    fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(payload),
+      signal: signal
+    })
+    .then(response => {
+      if (timeoutId) clearTimeout(timeoutId);
+    })
+    .catch(error => {
+      // Fail-open: ignore errors so the agent/editor remains unaffected
+      if (timeoutId) clearTimeout(timeoutId);
+    });
+  }
+})();

--- a/gestalt_cli/src/observe/inject.rs
+++ b/gestalt_cli/src/observe/inject.rs
@@ -1,0 +1,167 @@
+use serde_json::{json, Value};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+/// Safe-merge Codex hooks while preserving existing structures and keys, specifically avoiding duplicate hooks.
+pub fn merge_codex_hooks(existing: &str, new_hook_json: &str) -> String {
+    // Parse existing JSON or default to a clean object
+    let mut root: Value = serde_json::from_str(existing).unwrap_or_else(|_| json!({}));
+
+    // Ensure we have a top-level "hooks" object
+    if !root.is_object() {
+        root = json!({"hooks": {}});
+    } else if root.get("hooks").is_none() || !root["hooks"].is_object() {
+        root.as_object_mut()
+            .unwrap()
+            .insert("hooks".to_string(), json!({}));
+    }
+
+    let hooks_obj = root["hooks"].as_object_mut().unwrap();
+
+    // Parse the new hook JSON
+    let new_hook: Value = serde_json::from_str(new_hook_json).unwrap_or_else(|_| {
+        // If not valid JSON, treat it as a command string and construct the hook structure
+        json!({
+            "type": "command",
+            "command": new_hook_json,
+            "timeout": 10
+        })
+    });
+
+    // Merge the hook under standard Codex event keys
+    for event_key in &["SessionStart", "UserPromptSubmit"] {
+        let entry = hooks_obj
+            .entry(event_key.to_string())
+            .or_insert_with(|| json!([]));
+        if !entry.is_array() {
+            *entry = json!([]);
+        }
+        let arr = entry.as_array_mut().unwrap();
+
+        // Codex/Orca structure: event_key: [{ "hooks": [{type: "command", command: "...", timeout: 10}] }]
+        // If the array is empty, we initialize it with a single group { "hooks": [] }
+        if arr.is_empty() {
+            arr.push(json!({ "hooks": [] }));
+        }
+
+        let mut appended = false;
+        for group in arr.iter_mut() {
+            if let Some(group_obj) = group.as_object_mut() {
+                let inner_hooks_entry = group_obj
+                    .entry("hooks".to_string())
+                    .or_insert_with(|| json!([]));
+                if let Some(inner_hooks_arr) = inner_hooks_entry.as_array_mut() {
+                    // Check if our hook is already present in this group's hooks array (based on 'command' field)
+                    let already_exists = inner_hooks_arr.iter().any(|h| {
+                        h.get("command").and_then(|c| c.as_str())
+                            == new_hook.get("command").and_then(|c| c.as_str())
+                    });
+
+                    if !already_exists {
+                        inner_hooks_arr.push(new_hook.clone());
+                        appended = true;
+                        break;
+                    } else {
+                        // Already exists, don't add duplicate
+                        appended = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        // If not appended yet (e.g. elements in the array weren't objects with "hooks"), push a new group
+        if !appended {
+            arr.push(json!({
+                "hooks": [new_hook.clone()]
+            }));
+        }
+    }
+
+    serde_json::to_string_pretty(&root).unwrap_or_else(|_| existing.to_string())
+}
+
+/// Safe-merge Claude settings while preserving existing keys.
+pub fn merge_claude_settings(existing: &str, new_hook_cmd: &str) -> String {
+    let mut root: Value = serde_json::from_str(existing).unwrap_or_else(|_| json!({}));
+
+    if !root.is_object() {
+        root = json!({});
+    }
+
+    let root_obj = root.as_object_mut().unwrap();
+
+    // Merge into a "hooks" field at the top-level
+    let hooks_obj = root_obj
+        .entry("hooks".to_string())
+        .or_insert_with(|| json!({}));
+    if !hooks_obj.is_object() {
+        *hooks_obj = json!({});
+    }
+
+    let hooks_map = hooks_obj.as_object_mut().unwrap();
+
+    // Use a "post_run" hook list
+    let entry = hooks_map
+        .entry("post_run".to_string())
+        .or_insert_with(|| json!([]));
+    if !entry.is_array() {
+        *entry = json!([]);
+    }
+    let arr = entry.as_array_mut().unwrap();
+
+    let already_exists = arr.iter().any(|v| v.as_str() == Some(new_hook_cmd));
+    if !already_exists {
+        arr.push(Value::String(new_hook_cmd.to_string()));
+    }
+
+    serde_json::to_string_pretty(&root).unwrap_or_else(|_| existing.to_string())
+}
+
+/// Dynamically builds the observation hook script with replaced agent, event, and summary values.
+pub fn build_hook_script(agent: &str, event_type: &str, summary: &str) -> String {
+    let base_script = include_str!("assets/gestalt-observe-hook.sh");
+    base_script
+        .replace("unknown-agent", agent)
+        .replace("run_started", event_type)
+        .replace("Agent execution event", summary)
+}
+
+/// Inject the Opencode status plugin JS into the given config directory.
+pub fn inject_opencode_plugin(config_dir: &Path) -> std::io::Result<PathBuf> {
+    let plugin_path = config_dir.join("plugins").join("gestalt-observe-status.js");
+    if let Some(parent) = plugin_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let content = include_str!("assets/gestalt-observe-status.js");
+    fs::write(&plugin_path, content)?;
+    Ok(plugin_path)
+}
+
+/// Inject the Codex hooks into hooks.json under the given directory.
+pub fn inject_codex_hooks(codex_dir: &Path, new_hook_cmd: &str) -> std::io::Result<PathBuf> {
+    fs::create_dir_all(codex_dir)?;
+    let hooks_file = codex_dir.join("hooks.json");
+    let existing = if hooks_file.exists() {
+        fs::read_to_string(&hooks_file)?
+    } else {
+        String::new()
+    };
+    let merged = merge_codex_hooks(&existing, new_hook_cmd);
+    fs::write(&hooks_file, merged)?;
+    Ok(hooks_file)
+}
+
+/// Inject the Claude settings into settings.json under the given directory.
+pub fn inject_claude_settings(claude_dir: &Path, new_hook_cmd: &str) -> std::io::Result<PathBuf> {
+    fs::create_dir_all(claude_dir)?;
+    let settings_file = claude_dir.join("settings.json");
+    let existing = if settings_file.exists() {
+        fs::read_to_string(&settings_file)?
+    } else {
+        String::new()
+    };
+    let merged = merge_claude_settings(&existing, new_hook_cmd);
+    fs::write(&settings_file, merged)?;
+    Ok(settings_file)
+}

--- a/gestalt_cli/tests/inject_test.rs
+++ b/gestalt_cli/tests/inject_test.rs
@@ -36,28 +36,48 @@ fn test_merge_real_orca_hooks() {
 
     // Merge our hook
     let merged = inject::merge_codex_hooks(orca_hooks_json, our_hook_cmd);
-    let parsed: serde_json::Value = serde_json::from_str(&merged).expect("Failed to parse merged json");
+    let parsed: serde_json::Value =
+        serde_json::from_str(&merged).expect("Failed to parse merged json");
 
     // Verify top-level structure
     assert!(parsed.is_object());
-    let hooks_obj = parsed.get("hooks").and_then(|h| h.as_object()).expect("hooks should be an object");
+    let hooks_obj = parsed
+        .get("hooks")
+        .and_then(|h| h.as_object())
+        .expect("hooks should be an object");
 
     // Verify SessionStart and UserPromptSubmit exist
     for key in &["SessionStart", "UserPromptSubmit"] {
-        let list = hooks_obj.get(*key).and_then(|v| v.as_array()).expect("event key should be an array");
+        let list = hooks_obj
+            .get(*key)
+            .and_then(|v| v.as_array())
+            .expect("event key should be an array");
         assert_eq!(list.len(), 1);
         let group = list[0].as_object().expect("group should be an object");
-        let inner_hooks = group.get("hooks").and_then(|v| v.as_array()).expect("inner hooks should be an array");
+        let inner_hooks = group
+            .get("hooks")
+            .and_then(|v| v.as_array())
+            .expect("inner hooks should be an array");
 
         // Should now have 2 hooks: Orca's and ours
-        assert_eq!(inner_hooks.len(), 2, "Expected exactly 2 hooks in the group (Orca's + ours)");
+        assert_eq!(
+            inner_hooks.len(),
+            2,
+            "Expected exactly 2 hooks in the group (Orca's + ours)"
+        );
 
         // First hook must be Orca's
-        let first_cmd = inner_hooks[0].get("command").and_then(|c| c.as_str()).unwrap();
+        let first_cmd = inner_hooks[0]
+            .get("command")
+            .and_then(|c| c.as_str())
+            .unwrap();
         assert!(first_cmd.contains("orca"));
 
         // Second hook must be ours
-        let second_cmd = inner_hooks[1].get("command").and_then(|c| c.as_str()).unwrap();
+        let second_cmd = inner_hooks[1]
+            .get("command")
+            .and_then(|c| c.as_str())
+            .unwrap();
         assert_eq!(second_cmd, our_hook_cmd);
     }
 }
@@ -70,16 +90,24 @@ fn test_merge_codex_hooks_idempotent() {
     // First merge
     let merged_once = inject::merge_codex_hooks(empty_json, hook_cmd);
     let parsed_once: serde_json::Value = serde_json::from_str(&merged_once).unwrap();
-    let hooks_once = parsed_once["hooks"]["SessionStart"][0]["hooks"].as_array().unwrap();
+    let hooks_once = parsed_once["hooks"]["SessionStart"][0]["hooks"]
+        .as_array()
+        .unwrap();
     assert_eq!(hooks_once.len(), 1);
 
     // Second merge with same command
     let merged_twice = inject::merge_codex_hooks(&merged_once, hook_cmd);
     let parsed_twice: serde_json::Value = serde_json::from_str(&merged_twice).unwrap();
-    let hooks_twice = parsed_twice["hooks"]["SessionStart"][0]["hooks"].as_array().unwrap();
+    let hooks_twice = parsed_twice["hooks"]["SessionStart"][0]["hooks"]
+        .as_array()
+        .unwrap();
 
     // No duplicate hooks should be added
-    assert_eq!(hooks_twice.len(), 1, "Idempotency failed: duplicate hook added");
+    assert_eq!(
+        hooks_twice.len(),
+        1,
+        "Idempotency failed: duplicate hook added"
+    );
     assert_eq!(hooks_twice[0]["command"].as_str().unwrap(), hook_cmd);
 }
 
@@ -91,22 +119,42 @@ fn test_build_hook_script_contents() {
     // 1. 8081/api/event
     // 2. timeout <= 10s (max-time 10)
     // 3. fail-open fallback (|| :)
-    assert!(script.contains("8081/api/event"), "Script does not contain endpoint 8081/api/event");
-    assert!(script.contains("--max-time 10") || script.contains("-m 10") || script.contains("timeout"), "Script does not enforce timeout of 10s");
-    assert!(script.contains("|| :") || script.contains("|| true"), "Script does not implement fail-open fallback");
-    assert!(script.contains("test-agent"), "Script did not substitute agent name");
-    assert!(script.contains("test-event"), "Script did not substitute event type");
-    assert!(script.contains("test summary description"), "Script did not substitute summary");
+    assert!(
+        script.contains("8081/api/event"),
+        "Script does not contain endpoint 8081/api/event"
+    );
+    assert!(
+        script.contains("--max-time 10") || script.contains("-m 10") || script.contains("timeout"),
+        "Script does not enforce timeout of 10s"
+    );
+    assert!(
+        script.contains("|| :") || script.contains("|| true"),
+        "Script does not implement fail-open fallback"
+    );
+    assert!(
+        script.contains("test-agent"),
+        "Script did not substitute agent name"
+    );
+    assert!(
+        script.contains("test-event"),
+        "Script did not substitute event type"
+    );
+    assert!(
+        script.contains("test summary description"),
+        "Script did not substitute summary"
+    );
 }
 
 #[test]
 fn test_injectors_with_temp_dir() {
-    let base_path = std::env::temp_dir().join(format!("gestalt-inject-test-{}", uuid::Uuid::new_v4()));
+    let base_path =
+        std::env::temp_dir().join(format!("gestalt-inject-test-{}", uuid::Uuid::new_v4()));
     fs::create_dir_all(&base_path).expect("Failed to create temp directory");
 
     // 1. Inject Opencode plugin
     let opencode_dir = base_path.join("opencode");
-    let plugin_path = inject::inject_opencode_plugin(&opencode_dir).expect("Failed to inject opencode plugin");
+    let plugin_path =
+        inject::inject_opencode_plugin(&opencode_dir).expect("Failed to inject opencode plugin");
     assert!(plugin_path.exists());
     let plugin_content = fs::read_to_string(&plugin_path).unwrap();
     assert!(plugin_content.contains("8081/api/event"));
@@ -114,21 +162,27 @@ fn test_injectors_with_temp_dir() {
 
     // 2. Inject Codex hooks
     let codex_dir = base_path.join("codex");
-    let hooks_file = inject::inject_codex_hooks(&codex_dir, "my-gestalt-hook-command").expect("Failed to inject codex hooks");
+    let hooks_file = inject::inject_codex_hooks(&codex_dir, "my-gestalt-hook-command")
+        .expect("Failed to inject codex hooks");
     assert!(hooks_file.exists());
     let hooks_content = fs::read_to_string(&hooks_file).unwrap();
     assert!(hooks_content.contains("my-gestalt-hook-command"));
 
     // Inject same Codex hooks again (idempotent)
-    inject::inject_codex_hooks(&codex_dir, "my-gestalt-hook-command").expect("Failed to inject codex hooks again");
+    inject::inject_codex_hooks(&codex_dir, "my-gestalt-hook-command")
+        .expect("Failed to inject codex hooks again");
     let hooks_content_after = fs::read_to_string(&hooks_file).unwrap();
     let parsed: serde_json::Value = serde_json::from_str(&hooks_content_after).unwrap();
-    let len = parsed["hooks"]["SessionStart"][0]["hooks"].as_array().unwrap().len();
+    let len = parsed["hooks"]["SessionStart"][0]["hooks"]
+        .as_array()
+        .unwrap()
+        .len();
     assert_eq!(len, 1);
 
     // 3. Inject Claude settings
     let claude_dir = base_path.join("claude");
-    let settings_file = inject::inject_claude_settings(&claude_dir, "my-claude-hook-command").expect("Failed to inject claude settings");
+    let settings_file = inject::inject_claude_settings(&claude_dir, "my-claude-hook-command")
+        .expect("Failed to inject claude settings");
     assert!(settings_file.exists());
     let settings_content = fs::read_to_string(&settings_file).unwrap();
     assert!(settings_content.contains("my-claude-hook-command"));

--- a/gestalt_cli/tests/inject_test.rs
+++ b/gestalt_cli/tests/inject_test.rs
@@ -1,0 +1,138 @@
+#[path = "../src/observe/inject.rs"]
+pub mod inject;
+
+use std::fs;
+
+#[test]
+fn test_merge_real_orca_hooks() {
+    let orca_hooks_json = r#"{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/bin/sh -c \"if [ -f ~/.orca/agent-hooks/codex-hook.sh ] && [ -r ~/.orca/agent-hooks/codex-hook.sh ] && [ -x ~/.orca/agent-hooks/codex-hook.sh ]; then ~/.orca/agent-hooks/codex-hook.sh; else cat >/dev/null 2>&1 || :; fi\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/bin/sh -c \"if [ -f ~/.orca/agent-hooks/codex-hook.sh ] && [ -r ~/.orca/agent-hooks/codex-hook.sh ] && [ -x ~/.orca/agent-hooks/codex-hook.sh ]; then ~/.orca/agent-hooks/codex-hook.sh; else cat >/dev/null 2>&1 || :; fi\"",
+            "timeout": 10
+          }
+        ]
+      }
+    ]
+  }
+}"#;
+
+    let our_hook_cmd = "curl -s -X POST http://127.0.0.1:8081/api/event";
+
+    // Merge our hook
+    let merged = inject::merge_codex_hooks(orca_hooks_json, our_hook_cmd);
+    let parsed: serde_json::Value = serde_json::from_str(&merged).expect("Failed to parse merged json");
+
+    // Verify top-level structure
+    assert!(parsed.is_object());
+    let hooks_obj = parsed.get("hooks").and_then(|h| h.as_object()).expect("hooks should be an object");
+
+    // Verify SessionStart and UserPromptSubmit exist
+    for key in &["SessionStart", "UserPromptSubmit"] {
+        let list = hooks_obj.get(*key).and_then(|v| v.as_array()).expect("event key should be an array");
+        assert_eq!(list.len(), 1);
+        let group = list[0].as_object().expect("group should be an object");
+        let inner_hooks = group.get("hooks").and_then(|v| v.as_array()).expect("inner hooks should be an array");
+
+        // Should now have 2 hooks: Orca's and ours
+        assert_eq!(inner_hooks.len(), 2, "Expected exactly 2 hooks in the group (Orca's + ours)");
+
+        // First hook must be Orca's
+        let first_cmd = inner_hooks[0].get("command").and_then(|c| c.as_str()).unwrap();
+        assert!(first_cmd.contains("orca"));
+
+        // Second hook must be ours
+        let second_cmd = inner_hooks[1].get("command").and_then(|c| c.as_str()).unwrap();
+        assert_eq!(second_cmd, our_hook_cmd);
+    }
+}
+
+#[test]
+fn test_merge_codex_hooks_idempotent() {
+    let empty_json = "{}";
+    let hook_cmd = "curl -s -X POST http://127.0.0.1:8081/api/event";
+
+    // First merge
+    let merged_once = inject::merge_codex_hooks(empty_json, hook_cmd);
+    let parsed_once: serde_json::Value = serde_json::from_str(&merged_once).unwrap();
+    let hooks_once = parsed_once["hooks"]["SessionStart"][0]["hooks"].as_array().unwrap();
+    assert_eq!(hooks_once.len(), 1);
+
+    // Second merge with same command
+    let merged_twice = inject::merge_codex_hooks(&merged_once, hook_cmd);
+    let parsed_twice: serde_json::Value = serde_json::from_str(&merged_twice).unwrap();
+    let hooks_twice = parsed_twice["hooks"]["SessionStart"][0]["hooks"].as_array().unwrap();
+
+    // No duplicate hooks should be added
+    assert_eq!(hooks_twice.len(), 1, "Idempotency failed: duplicate hook added");
+    assert_eq!(hooks_twice[0]["command"].as_str().unwrap(), hook_cmd);
+}
+
+#[test]
+fn test_build_hook_script_contents() {
+    let script = inject::build_hook_script("test-agent", "test-event", "test summary description");
+
+    // Hook script must contain:
+    // 1. 8081/api/event
+    // 2. timeout <= 10s (max-time 10)
+    // 3. fail-open fallback (|| :)
+    assert!(script.contains("8081/api/event"), "Script does not contain endpoint 8081/api/event");
+    assert!(script.contains("--max-time 10") || script.contains("-m 10") || script.contains("timeout"), "Script does not enforce timeout of 10s");
+    assert!(script.contains("|| :") || script.contains("|| true"), "Script does not implement fail-open fallback");
+    assert!(script.contains("test-agent"), "Script did not substitute agent name");
+    assert!(script.contains("test-event"), "Script did not substitute event type");
+    assert!(script.contains("test summary description"), "Script did not substitute summary");
+}
+
+#[test]
+fn test_injectors_with_temp_dir() {
+    let base_path = std::env::temp_dir().join(format!("gestalt-inject-test-{}", uuid::Uuid::new_v4()));
+    fs::create_dir_all(&base_path).expect("Failed to create temp directory");
+
+    // 1. Inject Opencode plugin
+    let opencode_dir = base_path.join("opencode");
+    let plugin_path = inject::inject_opencode_plugin(&opencode_dir).expect("Failed to inject opencode plugin");
+    assert!(plugin_path.exists());
+    let plugin_content = fs::read_to_string(&plugin_path).unwrap();
+    assert!(plugin_content.contains("8081/api/event"));
+    assert!(plugin_content.contains("opencode-plugin"));
+
+    // 2. Inject Codex hooks
+    let codex_dir = base_path.join("codex");
+    let hooks_file = inject::inject_codex_hooks(&codex_dir, "my-gestalt-hook-command").expect("Failed to inject codex hooks");
+    assert!(hooks_file.exists());
+    let hooks_content = fs::read_to_string(&hooks_file).unwrap();
+    assert!(hooks_content.contains("my-gestalt-hook-command"));
+
+    // Inject same Codex hooks again (idempotent)
+    inject::inject_codex_hooks(&codex_dir, "my-gestalt-hook-command").expect("Failed to inject codex hooks again");
+    let hooks_content_after = fs::read_to_string(&hooks_file).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&hooks_content_after).unwrap();
+    let len = parsed["hooks"]["SessionStart"][0]["hooks"].as_array().unwrap().len();
+    assert_eq!(len, 1);
+
+    // 3. Inject Claude settings
+    let claude_dir = base_path.join("claude");
+    let settings_file = inject::inject_claude_settings(&claude_dir, "my-claude-hook-command").expect("Failed to inject claude settings");
+    assert!(settings_file.exists());
+    let settings_content = fs::read_to_string(&settings_file).unwrap();
+    assert!(settings_content.contains("my-claude-hook-command"));
+
+    // Clean up
+    let _ = fs::remove_dir_all(&base_path);
+}


### PR DESCRIPTION
This pull request implements feature FEAT-GT-040 for the Gestalt framework's observe layer. It implements safe, idempotent hook and settings injectors for Codex (`hooks.json`), Claude (`settings.json`), and Opencode (JS plugins). All injected hooks are fully fail-open with a 10s timeout, silent error handling, and send POST requests to the event bus at `http://127.0.0.1:8081/api/event`.

Key Changes:
1. `gestalt_cli/src/observe/inject.rs`: Implements `merge_codex_hooks` (safely preserves Orca structures and existing keys while avoiding duplicate hooks), `merge_claude_settings`, `build_hook_script`, and directory injectors.
2. `gestalt_cli/src/observe/assets/gestalt-observe-hook.sh`: Fail-open, 10-second timeout curl-based shell hook.
3. `gestalt_cli/src/observe/assets/gestalt-observe-status.js`: Fail-open, 10-second timeout `AbortController` fetch-based Javascript plugin template.
4. `gestalt_cli/tests/inject_test.rs`: Unit and integration tests for all injectors and build helpers. Verified idempotent behavior and full integration with real Orca hooks.

Verification:
- `cargo test -p gestalt_cli --test inject_test` passes cleanly (4/4 tests).
- `cargo clippy -p gestalt_cli --all-targets -- -D warnings` compiles without warnings or errors.

Fixes #512

---
*PR created automatically by Jules for task [4087764045469793609](https://jules.google.com/task/4087764045469793609) started by @iberi22*