### PR TITLE
feat: flight recorder data layer run reconstruction by run_id

### DIFF
--- a/gestalt-router/src/timeline.rs
+++ b/gestalt-router/src/timeline.rs
@@ -104,6 +104,11 @@ impl StateDbEventLog {
     pub fn new(db: Arc<StateDb>, run_id: Uuid) -> Self {
         Self { db, run_id }
     }
+
+    /// Reconstructs the run using the log's own run_id and db reference.
+    pub fn reconstruct(&self) -> Result<(Vec<Event>, AgentState), crate::run::RouterError> {
+        reconstruct_run(self.run_id, &self.db)
+    }
 }
 
 impl EventLog for StateDbEventLog {
@@ -182,4 +187,56 @@ fn extract_event_type(event: &Event) -> String {
         Event::ExcludedFile { .. } => "excluded_file",
     }
     .to_string()
+}
+
+/// Standalone helper to reconstruct a run's event sequence and compute the final state of its agent(s).
+pub fn reconstruct_run(
+    run_id: Uuid,
+    db: &StateDb,
+) -> Result<(Vec<Event>, AgentState), crate::run::RouterError> {
+    // 1. Fetch chronological timeline events using our new `timeline_by_run`
+    let raw_events = db
+        .timeline_by_run(&run_id.to_string())
+        .map_err(|e| crate::run::RouterError::timeline_error(e.to_string()))?;
+
+    // 2. Parse raw events into `Event` enums
+    let mut parsed_events = Vec::new();
+    for raw in raw_events {
+        if let Ok(evt) = serde_json::from_str::<Event>(&raw.payload) {
+            parsed_events.push(evt);
+        }
+    }
+
+    // 3. Reconstruct final AgentState of the run.
+    // We can track the state of each agent in a HashMap.
+    let mut agent_states = std::collections::HashMap::new();
+    for event in &parsed_events {
+        if let Event::AgentStateChanged { agent_id, to, .. } = event {
+            agent_states.insert(agent_id.clone(), to.clone());
+        }
+    }
+
+    // Determine aggregate final state:
+    // If there are no agent states recorded, default to AgentState::Pending.
+    // Otherwise, calculate an overall state:
+    // Priority: Crashed > Timeout > Quarantined > Running > Success > NoChanges > Pending
+    let final_state = if agent_states.is_empty() {
+        AgentState::Pending
+    } else if agent_states.values().any(|s| matches!(s, AgentState::Crashed)) {
+        AgentState::Crashed
+    } else if agent_states.values().any(|s| matches!(s, AgentState::Timeout)) {
+        AgentState::Timeout
+    } else if agent_states.values().any(|s| matches!(s, AgentState::Quarantined)) {
+        AgentState::Quarantined
+    } else if agent_states.values().any(|s| matches!(s, AgentState::Running)) {
+        AgentState::Running
+    } else if agent_states.values().any(|s| matches!(s, AgentState::Success)) {
+        AgentState::Success
+    } else if agent_states.values().any(|s| matches!(s, AgentState::NoChanges)) {
+        AgentState::NoChanges
+    } else {
+        AgentState::Pending
+    };
+
+    Ok((parsed_events, final_state))
 }

--- a/gestalt-router/src/timeline.rs
+++ b/gestalt-router/src/timeline.rs
@@ -222,17 +222,35 @@ pub fn reconstruct_run(
     // Priority: Crashed > Timeout > Quarantined > Running > Success > NoChanges > Pending
     let final_state = if agent_states.is_empty() {
         AgentState::Pending
-    } else if agent_states.values().any(|s| matches!(s, AgentState::Crashed)) {
+    } else if agent_states
+        .values()
+        .any(|s| matches!(s, AgentState::Crashed))
+    {
         AgentState::Crashed
-    } else if agent_states.values().any(|s| matches!(s, AgentState::Timeout)) {
+    } else if agent_states
+        .values()
+        .any(|s| matches!(s, AgentState::Timeout))
+    {
         AgentState::Timeout
-    } else if agent_states.values().any(|s| matches!(s, AgentState::Quarantined)) {
+    } else if agent_states
+        .values()
+        .any(|s| matches!(s, AgentState::Quarantined))
+    {
         AgentState::Quarantined
-    } else if agent_states.values().any(|s| matches!(s, AgentState::Running)) {
+    } else if agent_states
+        .values()
+        .any(|s| matches!(s, AgentState::Running))
+    {
         AgentState::Running
-    } else if agent_states.values().any(|s| matches!(s, AgentState::Success)) {
+    } else if agent_states
+        .values()
+        .any(|s| matches!(s, AgentState::Success))
+    {
         AgentState::Success
-    } else if agent_states.values().any(|s| matches!(s, AgentState::NoChanges)) {
+    } else if agent_states
+        .values()
+        .any(|s| matches!(s, AgentState::NoChanges))
+    {
         AgentState::NoChanges
     } else {
         AgentState::Pending

--- a/gestalt-router/tests/router_tests.rs
+++ b/gestalt-router/tests/router_tests.rs
@@ -1307,3 +1307,77 @@ fn test_checkpoint_result_construction() {
     assert_eq!(deser.success, result.success);
     assert_eq!(deser.commit_sha, result.commit_sha);
 }
+
+#[test]
+fn test_reconstruct_run_helper() {
+    let tmp = TempDir::new("gestalt-reconstruct-test");
+    let db_path = tmp.path.join("test.db");
+    let db = Arc::new(StateDb::open(&db_path).unwrap());
+    let run_id = Uuid::new_v4();
+
+    let log = StateDbEventLog::new(db.clone(), run_id);
+
+    // Initial state: reconstructed run has no events and defaults to Pending
+    let (events, final_state) = gestalt_router::timeline::reconstruct_run(run_id, &db).unwrap();
+    assert!(events.is_empty());
+    assert_eq!(final_state, AgentState::Pending);
+
+    // Also test log method:
+    let (events_log, final_state_log) = log.reconstruct().unwrap();
+    assert!(events_log.is_empty());
+    assert_eq!(final_state_log, AgentState::Pending);
+
+    // Append some events
+    log.append(Event::RunStarted {
+        run_id,
+        task: "some task".into(),
+        agents: vec!["agent-a".into(), "agent-b".into()],
+        sha_base: "sha123".into(),
+    }).unwrap();
+
+    // Now append agent state changes
+    log.append(Event::AgentStateChanged {
+        run_id,
+        agent_id: "agent-a".into(),
+        from: AgentState::Pending,
+        to: AgentState::Running,
+    }).unwrap();
+
+    log.append(Event::AgentStateChanged {
+        run_id,
+        agent_id: "agent-b".into(),
+        from: AgentState::Pending,
+        to: AgentState::Running,
+    }).unwrap();
+
+    // Reconstruct at this point - both are Running, so aggregate is Running
+    let (events, final_state) = log.reconstruct().unwrap();
+    assert_eq!(events.len(), 3);
+    assert_eq!(final_state, AgentState::Running);
+
+    // Now agent-a succeeds
+    log.append(Event::AgentStateChanged {
+        run_id,
+        agent_id: "agent-a".into(),
+        from: AgentState::Running,
+        to: AgentState::Success,
+    }).unwrap();
+
+    // Reconstruct at this point - agent-a is Success, agent-b is Running. Aggregate should be Running.
+    let (events, final_state) = log.reconstruct().unwrap();
+    assert_eq!(events.len(), 4);
+    assert_eq!(final_state, AgentState::Running);
+
+    // Now agent-b crashes
+    log.append(Event::AgentStateChanged {
+        run_id,
+        agent_id: "agent-b".into(),
+        from: AgentState::Running,
+        to: AgentState::Crashed,
+    }).unwrap();
+
+    // Reconstruct - agent-a is Success, agent-b is Crashed. Aggregate should be Crashed.
+    let (events, final_state) = log.reconstruct().unwrap();
+    assert_eq!(events.len(), 5);
+    assert_eq!(final_state, AgentState::Crashed);
+}

--- a/gestalt-router/tests/router_tests.rs
+++ b/gestalt-router/tests/router_tests.rs
@@ -1333,7 +1333,8 @@ fn test_reconstruct_run_helper() {
         task: "some task".into(),
         agents: vec!["agent-a".into(), "agent-b".into()],
         sha_base: "sha123".into(),
-    }).unwrap();
+    })
+    .unwrap();
 
     // Now append agent state changes
     log.append(Event::AgentStateChanged {
@@ -1341,14 +1342,16 @@ fn test_reconstruct_run_helper() {
         agent_id: "agent-a".into(),
         from: AgentState::Pending,
         to: AgentState::Running,
-    }).unwrap();
+    })
+    .unwrap();
 
     log.append(Event::AgentStateChanged {
         run_id,
         agent_id: "agent-b".into(),
         from: AgentState::Pending,
         to: AgentState::Running,
-    }).unwrap();
+    })
+    .unwrap();
 
     // Reconstruct at this point - both are Running, so aggregate is Running
     let (events, final_state) = log.reconstruct().unwrap();
@@ -1361,7 +1364,8 @@ fn test_reconstruct_run_helper() {
         agent_id: "agent-a".into(),
         from: AgentState::Running,
         to: AgentState::Success,
-    }).unwrap();
+    })
+    .unwrap();
 
     // Reconstruct at this point - agent-a is Success, agent-b is Running. Aggregate should be Running.
     let (events, final_state) = log.reconstruct().unwrap();
@@ -1374,7 +1378,8 @@ fn test_reconstruct_run_helper() {
         agent_id: "agent-b".into(),
         from: AgentState::Running,
         to: AgentState::Crashed,
-    }).unwrap();
+    })
+    .unwrap();
 
     // Reconstruct - agent-a is Success, agent-b is Crashed. Aggregate should be Crashed.
     let (events, final_state) = log.reconstruct().unwrap();

--- a/gestalt-state/src/statedb.rs
+++ b/gestalt-state/src/statedb.rs
@@ -526,6 +526,44 @@ impl StateDb {
 
         Ok(events)
     }
+
+    /// Fetch ALL timeline events for a given run, ordered chronologically (by sequence ASC).
+    pub fn timeline_by_run(&self, run_id: &str) -> Result<Vec<TimelineEvent>> {
+        let conn = self.conn.lock().unwrap();
+        let mut stmt = conn
+            .prepare(
+                "SELECT seq, run_id, agent_id, event_type, payload, created_at
+                 FROM timeline WHERE run_id = ?1
+                 ORDER BY seq ASC",
+            )
+            .context("Failed to prepare timeline_by_run query")?;
+
+        let events = stmt
+            .query_map(rusqlite::params![run_id], |row| {
+                let seq: i64 = row.get(0)?;
+                let created_at_str: String = row.get(5)?;
+                Ok(TimelineEvent {
+                    seq: Some(seq),
+                    run_id: row.get(1)?,
+                    agent_id: row.get(2)?,
+                    event_type: row.get(3)?,
+                    payload: row.get(4)?,
+                    created_at: created_at_str
+                        .parse::<DateTime<Utc>>()
+                        .unwrap_or_else(|_| Utc::now()),
+                })
+            })
+            .context("Failed to query timeline by run")?
+            .collect::<Result<Vec<_>, _>>()
+            .context("Failed to read timeline events by run")?;
+
+        Ok(events)
+    }
+}
+
+/// Standalone helper to fetch timeline events for a run, ordered chronologically (by sequence ASC).
+pub fn timeline_by_run(run_id: &str, db: &StateDb) -> Result<Vec<TimelineEvent>> {
+    db.timeline_by_run(run_id)
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────

--- a/gestalt-state/tests/flight_recorder_test.rs
+++ b/gestalt-state/tests/flight_recorder_test.rs
@@ -11,10 +11,18 @@ fn test_flight_recorder_interleaved() {
     db.create_run(run_b, r#"{"task": "task B"}"#).unwrap();
 
     // Push interleaved timeline events
-    let _a1 = db.push_event(run_a, Some("agent-1"), "started", r#"{"idx": 1}"#).unwrap();
-    let _b1 = db.push_event(run_b, Some("agent-2"), "started", r#"{"idx": 1}"#).unwrap();
-    let _a2 = db.push_event(run_a, Some("agent-1"), "completed", r#"{"idx": 2}"#).unwrap();
-    let _b2 = db.push_event(run_b, Some("agent-2"), "completed", r#"{"idx": 2}"#).unwrap();
+    let _a1 = db
+        .push_event(run_a, Some("agent-1"), "started", r#"{"idx": 1}"#)
+        .unwrap();
+    let _b1 = db
+        .push_event(run_b, Some("agent-2"), "started", r#"{"idx": 1}"#)
+        .unwrap();
+    let _a2 = db
+        .push_event(run_a, Some("agent-1"), "completed", r#"{"idx": 2}"#)
+        .unwrap();
+    let _b2 = db
+        .push_event(run_b, Some("agent-2"), "completed", r#"{"idx": 2}"#)
+        .unwrap();
 
     // Test timeline_by_run for run_a
     let timeline_a = db.timeline_by_run(run_a).expect("Failed to query run A");
@@ -25,7 +33,8 @@ fn test_flight_recorder_interleaved() {
     assert_eq!(timeline_a[1].payload, r#"{"idx": 2}"#);
 
     // Test standalone helper timeline_by_run as well
-    let timeline_a_standalone = gestalt_state::statedb::timeline_by_run(run_a, &db).expect("Failed to query run A with standalone helper");
+    let timeline_a_standalone = gestalt_state::statedb::timeline_by_run(run_a, &db)
+        .expect("Failed to query run A with standalone helper");
     assert_eq!(timeline_a_standalone.len(), 2);
 
     // Test timeline_by_run for run_b
@@ -43,9 +52,17 @@ fn test_flight_recorder_empty_run_id() {
 
     // Test with empty string
     let timeline_empty = db.timeline_by_run("").expect("Failed on empty run_id");
-    assert!(timeline_empty.is_empty(), "Empty run_id should return empty timeline");
+    assert!(
+        timeline_empty.is_empty(),
+        "Empty run_id should return empty timeline"
+    );
 
     // Test with nonexistent run_id
-    let timeline_nonexistent = db.timeline_by_run("nonexistent-id").expect("Failed on nonexistent run_id");
-    assert!(timeline_nonexistent.is_empty(), "Nonexistent run_id should return empty timeline");
+    let timeline_nonexistent = db
+        .timeline_by_run("nonexistent-id")
+        .expect("Failed on nonexistent run_id");
+    assert!(
+        timeline_nonexistent.is_empty(),
+        "Nonexistent run_id should return empty timeline"
+    );
 }

--- a/gestalt-state/tests/flight_recorder_test.rs
+++ b/gestalt-state/tests/flight_recorder_test.rs
@@ -1,0 +1,51 @@
+use gestalt_state::StateDb;
+
+#[test]
+fn test_flight_recorder_interleaved() {
+    let db = StateDb::open(":memory:").expect("Failed to open in-memory DB");
+
+    let run_a = "run-A";
+    let run_b = "run-B";
+
+    db.create_run(run_a, r#"{"task": "task A"}"#).unwrap();
+    db.create_run(run_b, r#"{"task": "task B"}"#).unwrap();
+
+    // Push interleaved timeline events
+    let _a1 = db.push_event(run_a, Some("agent-1"), "started", r#"{"idx": 1}"#).unwrap();
+    let _b1 = db.push_event(run_b, Some("agent-2"), "started", r#"{"idx": 1}"#).unwrap();
+    let _a2 = db.push_event(run_a, Some("agent-1"), "completed", r#"{"idx": 2}"#).unwrap();
+    let _b2 = db.push_event(run_b, Some("agent-2"), "completed", r#"{"idx": 2}"#).unwrap();
+
+    // Test timeline_by_run for run_a
+    let timeline_a = db.timeline_by_run(run_a).expect("Failed to query run A");
+    assert_eq!(timeline_a.len(), 2, "Should only have run A events");
+    assert_eq!(timeline_a[0].event_type, "started");
+    assert_eq!(timeline_a[1].event_type, "completed");
+    assert_eq!(timeline_a[0].payload, r#"{"idx": 1}"#);
+    assert_eq!(timeline_a[1].payload, r#"{"idx": 2}"#);
+
+    // Test standalone helper timeline_by_run as well
+    let timeline_a_standalone = gestalt_state::statedb::timeline_by_run(run_a, &db).expect("Failed to query run A with standalone helper");
+    assert_eq!(timeline_a_standalone.len(), 2);
+
+    // Test timeline_by_run for run_b
+    let timeline_b = db.timeline_by_run(run_b).expect("Failed to query run B");
+    assert_eq!(timeline_b.len(), 2, "Should only have run B events");
+    assert_eq!(timeline_b[0].event_type, "started");
+    assert_eq!(timeline_b[1].event_type, "completed");
+    assert_eq!(timeline_b[0].payload, r#"{"idx": 1}"#);
+    assert_eq!(timeline_b[1].payload, r#"{"idx": 2}"#);
+}
+
+#[test]
+fn test_flight_recorder_empty_run_id() {
+    let db = StateDb::open(":memory:").expect("Failed to open in-memory DB");
+
+    // Test with empty string
+    let timeline_empty = db.timeline_by_run("").expect("Failed on empty run_id");
+    assert!(timeline_empty.is_empty(), "Empty run_id should return empty timeline");
+
+    // Test with nonexistent run_id
+    let timeline_nonexistent = db.timeline_by_run("nonexistent-id").expect("Failed on nonexistent run_id");
+    assert!(timeline_nonexistent.is_empty(), "Nonexistent run_id should return empty timeline");
+}


### PR DESCRIPTION
This PR implements FEAT-GT-033: Flight recorder data layer - reconstructing a run end-to-end by run_id.

Key changes:
1. Implemented `timeline_by_run` on `StateDb` in `gestalt-state/src/statedb.rs` to fetch all timeline events for a run chronologically (`seq ASC`).
2. Implemented standalone helper `reconstruct_run` and `StateDbEventLog::reconstruct` inside `gestalt-router/src/timeline.rs` to parse raw events into `Event` variants and reconstruct the overall `AgentState` for the run based on the sequence.
3. Added a new unit test suite `gestalt-state/tests/flight_recorder_test.rs` to verify chronological and isolated retrieval of interleaved runs.
4. Added a new integration/unit test in `gestalt-router/tests/router_tests.rs` to verify state reconstruction under complex multi-agent state transition sequences.

Fixes #517

---
*PR created automatically by Jules for task [16336533821203904953](https://jules.google.com/task/16336533821203904953) started by @iberi22*