### PR TITLE
FEAT-GT-017 — Secret/token filter: redact or skip secrets before Xavier sink + WS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1927,6 +1927,7 @@ dependencies = [
  "gestalt-ws",
  "gestalt_core",
  "libc",
+ "regex",
  "serde",
  "serde_json",
  "sha2",

--- a/gestalt-router/Cargo.toml
+++ b/gestalt-router/Cargo.toml
@@ -19,6 +19,7 @@ gestalt-state = { path = "../gestalt-state" }
 gestalt-ws = { path = "../gestalt-ws" }
 sha2 = "0.10"
 chrono = "0.4"
+regex = "1.12.3"
 
 [dev-dependencies]
 tokio-tungstenite = "0.23"

--- a/gestalt-router/src/router.rs
+++ b/gestalt-router/src/router.rs
@@ -188,9 +188,9 @@ impl Router {
     fn broadcast_ws_event(&self, event: WsEvent) {
         if let Some(ref ws) = self.ws_server {
             let ws = ws.clone();
-            let event = event.clone();
+            let redacted_event = crate::xavier_sink::redact_ws_event(event);
             tokio::spawn(async move {
-                ws.broadcast(&event).await;
+                ws.broadcast(&redacted_event).await;
             });
         }
     }

--- a/gestalt-router/src/ws.rs
+++ b/gestalt-router/src/ws.rs
@@ -141,7 +141,8 @@ impl WsRouterBridge {
             },
         };
 
-        ws_server.broadcast(&ws_event).await;
+        let redacted_event = crate::xavier_sink::redact_ws_event(ws_event);
+        ws_server.broadcast(&redacted_event).await;
     }
 }
 

--- a/gestalt-router/src/xavier_sink.rs
+++ b/gestalt-router/src/xavier_sink.rs
@@ -10,10 +10,113 @@
 //! Failure policy: best-effort, fire-and-forget. The caller logs the error and
 //! the event remains durably in StateDb (replay-able via a cursor sweep).
 
+use std::sync::OnceLock;
+use regex::Regex;
+use gestalt_ws::WsEvent;
 use gestalt_core::application::agent::xavier::XavierClient;
 use serde_json::json;
 
 use crate::event_bus::BusEvent;
+
+/// Check if a given text contains sensitive patterns such as:
+/// XAVIER_TOKEN, password, token, secret, api_key, api-key, apikey, ghp_, or sk-.
+pub fn contains_secret(text: &str) -> bool {
+    static RE_SENSITIVE: OnceLock<Regex> = OnceLock::new();
+    let re = RE_SENSITIVE.get_or_init(|| {
+        Regex::new(r"(?i)XAVIER_TOKEN|password|token|secret|api[_-]?key|ghp_|sk-").unwrap()
+    });
+    re.is_match(text)
+}
+
+/// Redact sensitive data from a text, replacing keys' values and direct tokens with `[REDACTED]`.
+pub fn redact(text: &str) -> String {
+    // 1. Redact key-value pairs where key is case-insensitive match for keywords:
+    // XAVIER_TOKEN, password, token, secret, api_key, api-key, apikey
+    //
+    // Since Rust's regex crate does not support backreferences, we split the matching
+    // into three safe patterns: double-quoted values, single-quoted values, and unquoted values.
+
+    static RE_DOUBLE_QUOTED: OnceLock<Regex> = OnceLock::new();
+    let re_dq = RE_DOUBLE_QUOTED.get_or_init(|| {
+        Regex::new(r#"(?i)(XAVIER_TOKEN|password|token|secret|api[_-]?key)(\s*[:=]\s*)(")(.*?)(")"#).unwrap()
+    });
+
+    static RE_SINGLE_QUOTED: OnceLock<Regex> = OnceLock::new();
+    let re_sq = RE_SINGLE_QUOTED.get_or_init(|| {
+        Regex::new(r#"(?i)(XAVIER_TOKEN|password|token|secret|api[_-]?key)(\s*[:=]\s*)(')(.*?)(')"#).unwrap()
+    });
+
+    static RE_UNQUOTED: OnceLock<Regex> = OnceLock::new();
+    let re_unq = RE_UNQUOTED.get_or_init(|| {
+        Regex::new(r#"(?i)(XAVIER_TOKEN|password|token|secret|api[_-]?key)(\s*[:=]\s*)([^\s,"'\}]+)"#).unwrap()
+    });
+
+    let redacted_dq = re_dq.replace_all(text, "$1$2$3[REDACTED]$5");
+    let redacted_sq = re_sq.replace_all(&redacted_dq, "$1$2$3[REDACTED]$5");
+    let mut redacted = re_unq.replace_all(&redacted_sq, "$1$2[REDACTED]").into_owned();
+
+    // 2. Redact standalone tokens: ghp_... or sk-...
+    static RE_GHP: OnceLock<Regex> = OnceLock::new();
+    let re_ghp = RE_GHP.get_or_init(|| {
+        Regex::new(r"ghp_[a-zA-Z0-9]+").unwrap()
+    });
+
+    static RE_SK: OnceLock<Regex> = OnceLock::new();
+    let re_sk = RE_SK.get_or_init(|| {
+        Regex::new(r"sk-[a-zA-Z0-9_-]+").unwrap()
+    });
+
+    redacted = re_ghp.replace_all(&redacted, "[REDACTED]").into_owned();
+    redacted = re_sk.replace_all(&redacted, "[REDACTED]").into_owned();
+
+    redacted
+}
+
+/// Recursively redact any String value in JSON, and replace sensitive keys' values with `"[REDACTED]"`.
+pub fn redact_json(val: serde_json::Value) -> serde_json::Value {
+    match val {
+        serde_json::Value::String(s) => serde_json::Value::String(redact(&s)),
+        serde_json::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(redact_json).collect())
+        }
+        serde_json::Value::Object(obj) => {
+            let mut new_obj = serde_json::Map::new();
+            for (k, v) in obj {
+                let is_key_sensitive = contains_secret(&k);
+                if is_key_sensitive {
+                    new_obj.insert(k, serde_json::Value::String("[REDACTED]".to_string()));
+                } else {
+                    new_obj.insert(k, redact_json(v));
+                }
+            }
+            serde_json::Value::Object(new_obj)
+        }
+        other => other,
+    }
+}
+
+/// Apply redaction filter to a WsEvent.
+pub fn redact_ws_event(event: WsEvent) -> WsEvent {
+    match event {
+        WsEvent::RunStarted { run_id, task, agents } => WsEvent::RunStarted {
+            run_id,
+            task: redact(&task),
+            agents,
+        },
+        WsEvent::RunFinished { run_id, summary } => WsEvent::RunFinished {
+            run_id,
+            summary: redact(&summary),
+        },
+        WsEvent::ConflictDetected { run_id, agent_a, agent_b, path, message } => WsEvent::ConflictDetected {
+            run_id,
+            agent_a,
+            agent_b,
+            path,
+            message: redact(&message),
+        },
+        other => other,
+    }
+}
 
 /// Forwards bus events to Xavier as `kind=execution` memories.
 #[derive(Debug, Clone)]
@@ -59,6 +162,7 @@ impl XavierEventSink {
             ev.run_id.as_deref().unwrap_or("?"),
             ev.summary
         );
+        let redacted_content = redact(&content);
 
         let metadata = json!({
             "agent": ev.agent,
@@ -67,7 +171,7 @@ impl XavierEventSink {
             "state": ev.state,
             "event_type": ev.event_type,
             "ts": ev.ts,
-            "trace": ev.metadata,
+            "trace": redact_json(ev.metadata.clone()),
         });
 
         // Unique path per event: prefix + timestamp (+ run_id when present).
@@ -80,7 +184,7 @@ impl XavierEventSink {
         let path = format!("{}/{}-{}", self.path_prefix, ts_slug, run_slug);
 
         self.client
-            .add(&content, &path, "execution", metadata)
+            .add(&redacted_content, &path, "execution", metadata)
             .await
             .map_err(|e| {
                 crate::run::RouterError::timeline_error(format!("Xavier sink failed: {}", e))

--- a/gestalt-router/src/xavier_sink.rs
+++ b/gestalt-router/src/xavier_sink.rs
@@ -10,11 +10,11 @@
 //! Failure policy: best-effort, fire-and-forget. The caller logs the error and
 //! the event remains durably in StateDb (replay-able via a cursor sweep).
 
-use std::sync::OnceLock;
-use regex::Regex;
-use gestalt_ws::WsEvent;
 use gestalt_core::application::agent::xavier::XavierClient;
+use gestalt_ws::WsEvent;
+use regex::Regex;
 use serde_json::json;
+use std::sync::OnceLock;
 
 use crate::event_bus::BusEvent;
 
@@ -38,33 +38,36 @@ pub fn redact(text: &str) -> String {
 
     static RE_DOUBLE_QUOTED: OnceLock<Regex> = OnceLock::new();
     let re_dq = RE_DOUBLE_QUOTED.get_or_init(|| {
-        Regex::new(r#"(?i)(XAVIER_TOKEN|password|token|secret|api[_-]?key)(\s*[:=]\s*)(")(.*?)(")"#).unwrap()
+        Regex::new(r#"(?i)(XAVIER_TOKEN|password|token|secret|api[_-]?key)(\s*[:=]\s*)(")(.*?)(")"#)
+            .unwrap()
     });
 
     static RE_SINGLE_QUOTED: OnceLock<Regex> = OnceLock::new();
     let re_sq = RE_SINGLE_QUOTED.get_or_init(|| {
-        Regex::new(r#"(?i)(XAVIER_TOKEN|password|token|secret|api[_-]?key)(\s*[:=]\s*)(')(.*?)(')"#).unwrap()
+        Regex::new(r#"(?i)(XAVIER_TOKEN|password|token|secret|api[_-]?key)(\s*[:=]\s*)(')(.*?)(')"#)
+            .unwrap()
     });
 
     static RE_UNQUOTED: OnceLock<Regex> = OnceLock::new();
     let re_unq = RE_UNQUOTED.get_or_init(|| {
-        Regex::new(r#"(?i)(XAVIER_TOKEN|password|token|secret|api[_-]?key)(\s*[:=]\s*)([^\s,"'\}]+)"#).unwrap()
+        Regex::new(
+            r#"(?i)(XAVIER_TOKEN|password|token|secret|api[_-]?key)(\s*[:=]\s*)([^\s,"'\}]+)"#,
+        )
+        .unwrap()
     });
 
     let redacted_dq = re_dq.replace_all(text, "$1$2$3[REDACTED]$5");
     let redacted_sq = re_sq.replace_all(&redacted_dq, "$1$2$3[REDACTED]$5");
-    let mut redacted = re_unq.replace_all(&redacted_sq, "$1$2[REDACTED]").into_owned();
+    let mut redacted = re_unq
+        .replace_all(&redacted_sq, "$1$2[REDACTED]")
+        .into_owned();
 
     // 2. Redact standalone tokens: ghp_... or sk-...
     static RE_GHP: OnceLock<Regex> = OnceLock::new();
-    let re_ghp = RE_GHP.get_or_init(|| {
-        Regex::new(r"ghp_[a-zA-Z0-9]+").unwrap()
-    });
+    let re_ghp = RE_GHP.get_or_init(|| Regex::new(r"ghp_[a-zA-Z0-9]+").unwrap());
 
     static RE_SK: OnceLock<Regex> = OnceLock::new();
-    let re_sk = RE_SK.get_or_init(|| {
-        Regex::new(r"sk-[a-zA-Z0-9_-]+").unwrap()
-    });
+    let re_sk = RE_SK.get_or_init(|| Regex::new(r"sk-[a-zA-Z0-9_-]+").unwrap());
 
     redacted = re_ghp.replace_all(&redacted, "[REDACTED]").into_owned();
     redacted = re_sk.replace_all(&redacted, "[REDACTED]").into_owned();
@@ -78,7 +81,7 @@ pub fn redact_json(val: serde_json::Value) -> serde_json::Value {
         serde_json::Value::String(s) => serde_json::Value::String(redact(&s)),
         serde_json::Value::Array(arr) => {
             serde_json::Value::Array(arr.into_iter().map(redact_json).collect())
-        }
+        },
         serde_json::Value::Object(obj) => {
             let mut new_obj = serde_json::Map::new();
             for (k, v) in obj {
@@ -90,7 +93,7 @@ pub fn redact_json(val: serde_json::Value) -> serde_json::Value {
                 }
             }
             serde_json::Value::Object(new_obj)
-        }
+        },
         other => other,
     }
 }
@@ -98,7 +101,11 @@ pub fn redact_json(val: serde_json::Value) -> serde_json::Value {
 /// Apply redaction filter to a WsEvent.
 pub fn redact_ws_event(event: WsEvent) -> WsEvent {
     match event {
-        WsEvent::RunStarted { run_id, task, agents } => WsEvent::RunStarted {
+        WsEvent::RunStarted {
+            run_id,
+            task,
+            agents,
+        } => WsEvent::RunStarted {
             run_id,
             task: redact(&task),
             agents,
@@ -107,7 +114,13 @@ pub fn redact_ws_event(event: WsEvent) -> WsEvent {
             run_id,
             summary: redact(&summary),
         },
-        WsEvent::ConflictDetected { run_id, agent_a, agent_b, path, message } => WsEvent::ConflictDetected {
+        WsEvent::ConflictDetected {
+            run_id,
+            agent_a,
+            agent_b,
+            path,
+            message,
+        } => WsEvent::ConflictDetected {
             run_id,
             agent_a,
             agent_b,

--- a/gestalt-router/tests/secret_filter_test.rs
+++ b/gestalt-router/tests/secret_filter_test.rs
@@ -1,0 +1,82 @@
+use gestalt_router::xavier_sink::{contains_secret, redact, redact_json};
+use serde_json::json;
+
+#[test]
+fn test_contains_secret_identifies_sensitive_patterns() {
+    // Sensitive patterns detected
+    assert!(contains_secret("XAVIER_TOKEN=somevalue"));
+    assert!(contains_secret("password: secretpassword"));
+    assert!(contains_secret("using token 123456"));
+    assert!(contains_secret("this is a secret"));
+    assert!(contains_secret("api_key=mykey"));
+    assert!(contains_secret("api-key=mykey"));
+    assert!(contains_secret("apikey: value"));
+    assert!(contains_secret("ghp_1234567890abcdefghijklmnopqrstuvwx"));
+    assert!(contains_secret("sk-proj-abcdefghijklmnopqrstuvwxyz"));
+
+    // Case insensitivity
+    assert!(contains_secret("xavier_token=somevalue"));
+    assert!(contains_secret("PASSWORD=123"));
+    assert!(contains_secret("SecretKey=xyz"));
+
+    // Normal strings unchanged / not detected
+    assert!(!contains_secret("hello world"));
+    assert!(!contains_secret("normal summary passes unchanged"));
+    assert!(!contains_secret("checkpoint committed"));
+}
+
+#[test]
+fn test_redact_filters_sensitive_patterns() {
+    // Test summary with XAVIER_TOKEN=abc123 -> [REDACTED]
+    let res = redact("XAVIER_TOKEN=abc123");
+    assert!(res.contains("[REDACTED]"));
+    assert!(!res.contains("abc123"));
+
+    // Test sk- OpenAI-style key and ghp_ GitHub token detected and redacted
+    let res_sk = redact("OpenAI key is sk-proj-12345abcde and github token is ghp_12345xyz");
+    assert!(res_sk.contains("[REDACTED]"));
+    assert!(!res_sk.contains("sk-proj-12345abcde"));
+    assert!(!res_sk.contains("ghp_12345xyz"));
+
+    // Test normal summary passes unchanged
+    let normal = "normal summary passes unchanged";
+    assert_eq!(redact(normal), normal);
+
+    // Test other variations of key-value pairs
+    let res_pwd = redact("password: 'abc'");
+    assert!(res_pwd.contains("[REDACTED]"));
+    assert!(!res_pwd.contains("abc"));
+
+    let res_apikey = redact("api-key=my-api-key-value");
+    assert!(res_apikey.contains("[REDACTED]"));
+    assert!(!res_apikey.contains("my-api-key-value"));
+}
+
+#[test]
+fn test_redact_json_filters_recursively() {
+    let payload = json!({
+        "agent": "hermes",
+        "nested": {
+            "password": "mysecretpassword",
+            "normal_field": "hello world"
+        },
+        "array_field": [
+            "normal string",
+            "ghp_12345678"
+        ],
+        "XAVIER_TOKEN": "some_token_value"
+    });
+
+    let redacted_payload = redact_json(payload);
+
+    // Verify sensitive keys are redacted
+    assert_eq!(redacted_payload["XAVIER_TOKEN"], "[REDACTED]");
+    assert_eq!(redacted_payload["nested"]["password"], "[REDACTED]");
+
+    // Verify recursive strings in array are redacted
+    assert_eq!(redacted_payload["array_field"][1], "[REDACTED]");
+
+    // Verify normal fields are untouched
+    assert_eq!(redacted_payload["nested"]["normal_field"], "hello world");
+    assert_eq!(redacted_payload["array_field"][0], "normal string");
+}


### PR DESCRIPTION
Implement secret and token filtering before streaming to the Xavier sink or broadcasting over WebSockets. This prevents any sensitive API keys or credentials from leaking.

Fixes #516

---
*PR created automatically by Jules for task [2320182253623664633](https://jules.google.com/task/2320182253623664633) started by @iberi22*