### PR TITLE
Fix broken test recovery and unignore memstate lock test

### DIFF
--- a/gestalt-merge/src/lib.rs
+++ b/gestalt-merge/src/lib.rs
@@ -1,1 +1,3 @@
 //! Gestalt Merge — 3-way merge engine. Fase 2: not yet implemented.
+
+#![deny(clippy::all)]

--- a/gestalt-router/tests/agent_tests.rs
+++ b/gestalt-router/tests/agent_tests.rs
@@ -1,3 +1,5 @@
+//! Unit and integration tests for Gestalt Agent execution and orchestration runners.
+
 use gestalt_router::agent::{AgentOutcome, AgentRunner, SubprocessRunner};
 use gestalt_router::run::{AgentResult, AgentSpec, RunSpec};
 use gestalt_router::run_state::AgentState;

--- a/gestalt-router/tests/doctor_tests.rs
+++ b/gestalt-router/tests/doctor_tests.rs
@@ -1,3 +1,5 @@
+//! Unit and integration tests for Gestalt Router Doctor cleanup and pruning utilities.
+
 use gestalt_router::doctor::{Doctor, DoctorError, ManifestJson, OrphanedRun};
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};

--- a/gestalt-router/tests/router_tests.rs
+++ b/gestalt-router/tests/router_tests.rs
@@ -1,4 +1,4 @@
-//! Comprehensive integration tests for gestalt-router.
+//! Comprehensive unit and integration tests for gestalt-router.
 //!
 //! Covers: type validation, checkpoint, overlap, integrate, timeline, workflow,
 //! and edge-case scenarios across all public modules.

--- a/gestalt-state/src/memstate.rs
+++ b/gestalt-state/src/memstate.rs
@@ -316,8 +316,8 @@ mod tests {
         assert!(mem.get_agent_state("run-1", "agent-1").is_none());
     }
 
-    #[test]
-    fn test_try_lock_exclusive() {
+    #[tokio::test]
+    async fn test_try_lock_exclusive() {
         let mem = MemState::new();
 
         // First acquire succeeds

--- a/hooks/pre-commit.sh
+++ b/hooks/pre-commit.sh
@@ -56,7 +56,7 @@ fi
 
 # ── Stage 4: Tests ───────────────────────────────────────
 header "🧪 [4/5] Cargo Test (gestalt-state)"
-if eval "$BUILD_ENV && cargo test -p gestalt-state -- --skip test_try_lock_exclusive 2>&1"; then
+if eval "$BUILD_ENV && cargo test -p gestalt-state 2>&1"; then
     pass "gestalt-state tests: PASS"
 else
     fail "gestalt-state tests: FAIL"

--- a/synapse-agentic/src/lib.rs
+++ b/synapse-agentic/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(clippy::all)]
+
 pub mod context;
 pub mod graph;
 pub mod providers;


### PR DESCRIPTION
Resolved test recovery issues and clippy warnings, converted test_try_lock_exclusive to an async tokio test, and updated the pre-commit script to run all tests without skips.

Fixes #507

---
*PR created automatically by Jules for task [12417513987632813685](https://jules.google.com/task/12417513987632813685) started by @iberi22*