### PR TITLE
feat(router): harden real-time conflict detection

### DIFF
--- a/gestalt-router/src/overlap.rs
+++ b/gestalt-router/src/overlap.rs
@@ -195,6 +195,9 @@ impl LiveConflictDetector {
     pub async fn run(self) {
         let mut rx = self.state.subscribe();
         let ws = self.ws.clone();
+        // Clone MemState without the sender, so the original sender is not kept alive in the loop!
+        let state_without_sender = self.state.without_sender();
+        drop(self);
 
         loop {
             match rx.recv().await {
@@ -208,8 +211,15 @@ impl LiveConflictDetector {
                             if let Some(path) = payload.get("path").and_then(|v| v.as_str()) {
                                 if let Some(ref agent_id) = event.agent_id {
                                     if let Some(holder) =
-                                        Self::check_lock(&self.state, path, agent_id)
+                                        Self::check_lock(&state_without_sender, path, agent_id)
                                     {
+                                        // Deterministic AgentState transition on conflict
+                                        state_without_sender.set_agent_state_silent(
+                                            &event.run_id,
+                                            agent_id,
+                                            "crashed",
+                                        );
+
                                         Self::broadcast_conflict(
                                             &ws,
                                             &event.run_id,
@@ -240,6 +250,14 @@ impl LiveConflictDetector {
                                 .get("agent_b")
                                 .and_then(|v| v.as_str())
                                 .unwrap_or("?");
+
+                            // Deterministic AgentState transition on conflict
+                            state_without_sender.set_agent_state_silent(
+                                &event.run_id,
+                                agent_b,
+                                "crashed",
+                            );
+
                             Self::broadcast_conflict(
                                 &ws,
                                 &event.run_id,

--- a/gestalt-router/tests/overlap_tests.rs
+++ b/gestalt-router/tests/overlap_tests.rs
@@ -57,6 +57,57 @@ fn test_detect_overlap_disjoint() {
     assert!(result.shared_paths.is_empty());
 }
 
+#[tokio::test]
+async fn test_concurrent_writes_conflict() {
+    use gestalt_router::overlap::LiveConflictDetector;
+    use gestalt_state::memstate::MemState;
+
+    // 1. Create MemState and subscribe to it
+    let mem_state = MemState::new();
+
+    // 2. Spawn LiveConflictDetector in a background task
+    let detector = LiveConflictDetector::new(mem_state.clone(), None);
+    let handle = tokio::spawn(detector.run());
+
+    // 3. Set Agent A to Running and acquire a lock
+    mem_state.set_agent_state("run-1", "agent-a", "running");
+    let lock_a = mem_state.try_lock("file.txt", "agent-a", "run-1", 30);
+    assert!(lock_a, "Agent A should successfully acquire the lock");
+
+    // 4. Set Agent B to Running and attempt to acquire the same lock
+    mem_state.set_agent_state("run-1", "agent-b", "running");
+    let lock_b = mem_state.try_lock("file.txt", "agent-b", "run-1", 30);
+    assert!(!lock_b, "Agent B lock acquisition should fail (conflict)");
+
+    // 5. Verify that Agent B's state transitions deterministically to "crashed" on conflict
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+    let state_b = mem_state.get_agent_state("run-1", "agent-b");
+    assert_eq!(
+        state_b,
+        Some("crashed".to_string()),
+        "Agent B's state should transition to crashed on conflict"
+    );
+
+    // Agent A should still be running cleanly
+    let state_a = mem_state.get_agent_state("run-1", "agent-a");
+    assert_eq!(
+        state_a,
+        Some("running".to_string()),
+        "Agent A's state should remain running"
+    );
+
+    // 6. Dropping mem_state and waiting for the detector task to finish cleanly
+    drop(mem_state);
+
+    // Wait for the spawned detector task to exit cleanly (should not block/timeout!)
+    let detector_finished = tokio::time::timeout(std::time::Duration::from_secs(2), handle).await;
+    assert!(
+        detector_finished.is_ok(),
+        "LiveConflictDetector task should terminate cleanly after MemState is dropped"
+    );
+}
+
 #[test]
 fn test_find_overlaps_empty_branches() {
     let repo_path = create_temp_git_repo();

--- a/gestalt-state/src/memstate.rs
+++ b/gestalt-state/src/memstate.rs
@@ -73,7 +73,25 @@ impl MemState {
         Self::with_capacity(capacity)
     }
 
+    /// Create a clone of this `MemState` that shares the same concurrent maps
+    /// but uses a separate, dummy broadcast channel. This is useful for preventing
+    /// background tasks from keeping the main broadcast sender alive (which causes leaks).
+    pub fn without_sender(&self) -> Self {
+        let (dummy_tx, _) = broadcast::channel(1);
+        Self {
+            agent_states: self.agent_states.clone(),
+            active_locks: self.active_locks.clone(),
+            event_tx: dummy_tx,
+        }
+    }
+
     // ── Agent State ───────────────────────────────────────────────────
+
+    /// Set the state of an agent within a run without broadcasting a timeline event.
+    pub fn set_agent_state_silent(&self, run_id: &str, agent_id: &str, state: &str) {
+        let key = format!("{run_id}:{agent_id}");
+        self.agent_states.insert(key, state.to_string());
+    }
 
     /// Get the current state of an agent within a run.
     ///
@@ -159,6 +177,8 @@ impl MemState {
                     })
                     .to_string();
                     self.push_event(run_id, Some(agent_id), "lock_conflict", &payload);
+                    // Deterministic AgentState transition on conflict
+                    self.set_agent_state(run_id, agent_id, "crashed");
                 }
             }
         }


### PR DESCRIPTION
Harden LiveConflictDetector to prevent broadcast channel leaks and implement deterministic agent transitions to crashed on lock conflicts.

Fixes #508

---
*PR created automatically by Jules for task [9128689636001386214](https://jules.google.com/task/9128689636001386214) started by @iberi22*