### PR TITLE
FEAT-GT-026 — kind=decision memories: durable architectural decision records in Xavier

### DIFF
--- a/gestalt_core/src/application/agent/xavier/agent.rs
+++ b/gestalt_core/src/application/agent/xavier/agent.rs
@@ -64,6 +64,15 @@ impl XavierAgent {
         Ok(response.id)
     }
 
+    /// Archive a decision memory
+    pub async fn archive_decision(
+        &self,
+        decision_text: &str,
+        metadata: serde_json::Value,
+    ) -> anyhow::Result<String> {
+        self.client.archive_decision(decision_text, metadata).await
+    }
+
     /// Get the node ID
     pub fn node_id(&self) -> &str {
         &self.node_id

--- a/gestalt_core/src/application/agent/xavier/client.rs
+++ b/gestalt_core/src/application/agent/xavier/client.rs
@@ -243,6 +243,20 @@ impl XavierClient {
         Ok(resp.id)
     }
 
+    /// Archive an architectural decision record in Xavier.
+    ///
+    /// Stores the serialized content with kind=`decision`.
+    pub async fn archive_decision(
+        &self,
+        decision_text: &str,
+        metadata: serde_json::Value,
+    ) -> anyhow::Result<String> {
+        let decision_id = uuid::Uuid::new_v4().to_string();
+        let path = format!("gestalt/decision/{decision_id}");
+        let resp = self.add(decision_text, &path, "decision", metadata).await?;
+        Ok(resp.id)
+    }
+
     /// Index a plan document in Xavier as kind=plan
     pub async fn save_plan(&self, content: &str, path: &str) -> Result<String, String> {
         self.add_memory(content, path, "plan").await
@@ -318,6 +332,26 @@ impl XavierClient {
         let mode = data["mode"].as_str().unwrap_or("unknown");
         Ok(mode.to_string())
     }
+}
+
+/// Pure helper to build a decision payload matching Xavier's AddMemoryPayload schema.
+pub fn build_decision_payload(
+    text: &str,
+    metadata: serde_json::Value,
+    user_id: &str,
+) -> Result<serde_json::Value, String> {
+    if text.trim().is_empty() {
+        return Err("text is required".to_string());
+    }
+    if user_id.trim().is_empty() {
+        return Err("user_id is required".to_string());
+    }
+    Ok(serde_json::json!({
+        "text": text,
+        "user_id": user_id,
+        "kind": "decision",
+        "metadata": metadata,
+    }))
 }
 
 #[cfg(test)]

--- a/gestalt_core/src/application/agent/xavier/mod.rs
+++ b/gestalt_core/src/application/agent/xavier/mod.rs
@@ -34,4 +34,4 @@ mod agent;
 mod client;
 
 pub use agent::XavierAgent;
-pub use client::XavierClient;
+pub use client::{XavierClient, build_decision_payload};

--- a/gestalt_core/tests/decision_memory_test.rs
+++ b/gestalt_core/tests/decision_memory_test.rs
@@ -1,0 +1,49 @@
+use gestalt_core::application::agent::xavier::{XavierClient, build_decision_payload};
+
+#[test]
+fn test_build_decision_payload_success() {
+    let text = "Implement durable decision memory";
+    let metadata = serde_json::json!({"issue": "GT-13"});
+    let user_id = "jules-007";
+
+    let result = build_decision_payload(text, metadata, user_id);
+    assert!(result.is_ok());
+
+    let payload = result.unwrap();
+    assert_eq!(payload["text"], "Implement durable decision memory");
+    assert_eq!(payload["user_id"], "jules-007");
+    assert_eq!(payload["kind"], "decision");
+    assert_eq!(payload["metadata"]["issue"], "GT-13");
+}
+
+#[test]
+fn test_build_decision_payload_missing_text() {
+    let text = "   ";
+    let metadata = serde_json::json!({});
+    let user_id = "jules-007";
+
+    let result = build_decision_payload(text, metadata, user_id);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("text is required"));
+}
+
+#[test]
+fn test_build_decision_payload_missing_user_id() {
+    let text = "Implement durable decision memory";
+    let metadata = serde_json::json!({});
+    let user_id = "";
+
+    let result = build_decision_payload(text, metadata, user_id);
+    assert!(result.is_err());
+    assert!(result.unwrap_err().contains("user_id is required"));
+}
+
+#[tokio::test]
+async fn test_archive_decision_compiles() {
+    // This test ensures archive_decision is fully implemented and compiles.
+    // We don't have a live server, so calling it should fail on request/connection,
+    // but the symbols are correctly resolved and compile.
+    let client = XavierClient::new("http://localhost:12345".to_string(), "test-token".to_string()).unwrap();
+    let res = client.archive_decision("Decide to use Rust", serde_json::json!({})).await;
+    assert!(res.is_err()); // Connection refused/failed
+}


### PR DESCRIPTION
Introduces archive_decision in both XavierClient and XavierAgent, along with the build_decision_payload helper and a dedicated test suite verifying payload validation and archival compilation.

Fixes #519

---
*PR created automatically by Jules for task [17552912838011768117](https://jules.google.com/task/17552912838011768117) started by @iberi22*