### PR TITLE
Implement BeliefGraph core

### DIFF
--- a/gestalt_core/src/domain/belief_graph.rs
+++ b/gestalt_core/src/domain/belief_graph.rs
@@ -1,0 +1,184 @@
+//! BeliefGraph core domain types and implementation.
+//!
+//! Defines the core data structures and graph logic for the belief graph:
+//! - `BeliefNode` — a concept node representing a belief.
+//! - `BeliefEdge` — a directed, weighted, typed connection between two nodes.
+//! - `BeliefGraph` — the flat adjacency/collection-based belief graph.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// A node representing a belief concept in the domain graph.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BeliefNode {
+    pub id: String,
+    pub label: String,
+    pub belief: f64, // ranges from 0.0 to 1.0 (0..1)
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A directed, typed edge connecting two `BeliefNode`s.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BeliefEdge {
+    pub from: String,
+    pub to: String,
+    pub weight: f64,
+    pub relation: String,
+}
+
+/// The non-thread-safe domain representation of a Belief Graph.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+pub struct BeliefGraph {
+    pub nodes: HashMap<String, BeliefNode>,
+    pub edges: Vec<BeliefEdge>,
+}
+
+impl BeliefGraph {
+    /// Create a new empty `BeliefGraph`.
+    pub fn new() -> Self {
+        Self {
+            nodes: HashMap::new(),
+            edges: Vec::new(),
+        }
+    }
+
+    /// Add a node to the graph. If it already exists, updates its label and belief.
+    pub fn add_node(&mut self, id: impl Into<String>, label: impl Into<String>, belief: f64) {
+        let id_str = id.into();
+        let clamped_belief = belief.clamp(0.0, 1.0);
+        let node = BeliefNode {
+            id: id_str.clone(),
+            label: label.into(),
+            belief: clamped_belief,
+            updated_at: Utc::now(),
+        };
+        self.nodes.insert(id_str, node);
+    }
+
+    /// Add an edge to the graph.
+    pub fn add_edge(&mut self, from: impl Into<String>, to: impl Into<String>, weight: f64, relation: impl Into<String>) {
+        let edge = BeliefEdge {
+            from: from.into(),
+            to: to.into(),
+            weight,
+            relation: relation.into(),
+        };
+        self.edges.push(edge);
+    }
+
+    /// Retrieve a reference to a node by its ID.
+    pub fn get_node(&self, id: &str) -> Option<&BeliefNode> {
+        self.nodes.get(id)
+    }
+
+    /// Update the belief score of a node if it exists, returning whether the update succeeded.
+    pub fn update_belief(&mut self, id: &str, belief: f64) -> bool {
+        if let Some(node) = self.nodes.get_mut(id) {
+            node.belief = belief.clamp(0.0, 1.0);
+            node.updated_at = Utc::now();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Get a list of target node IDs adjacent to the given node ID.
+    pub fn neighbors(&self, id: &str) -> Vec<String> {
+        self.edges
+            .iter()
+            .filter(|e| e.from == id)
+            .map(|e| e.to.clone())
+            .collect()
+    }
+
+    /// Export the graph representation as a JSON `Value`.
+    pub fn export_json(&self) -> serde_json::Value {
+        serde_json::to_value(self).unwrap_or(serde_json::Value::Null)
+    }
+
+    /// Serialize the current graph state to a JSON string.
+    pub fn save_to_string(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+
+    /// Load graph state from a JSON string.
+    pub fn load_from_string(json: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(json)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Conversion Traits for Integration with PR #503 / existing types
+// ---------------------------------------------------------------------------
+
+impl From<crate::domain::belief::BeliefNode> for BeliefNode {
+    fn from(n: crate::domain::belief::BeliefNode) -> Self {
+        Self {
+            id: n.id,
+            label: n.concept,
+            belief: n.confidence as f64,
+            updated_at: n.created_at,
+        }
+    }
+}
+
+impl From<BeliefNode> for crate::domain::belief::BeliefNode {
+    fn from(n: BeliefNode) -> Self {
+        Self {
+            id: n.id,
+            concept: n.label,
+            confidence: n.belief as f32,
+            language_family: None,
+            created_at: n.updated_at,
+        }
+    }
+}
+
+impl From<crate::domain::belief::BeliefEdge> for BeliefEdge {
+    fn from(e: crate::domain::belief::BeliefEdge) -> Self {
+        Self {
+            from: e.source,
+            to: e.target,
+            weight: e.weight as f64,
+            relation: e.relation_type,
+        }
+    }
+}
+
+impl From<BeliefEdge> for crate::domain::belief::BeliefEdge {
+    fn from(e: BeliefEdge) -> Self {
+        let now = Utc::now();
+        Self {
+            id: uuid::Uuid::new_v4().to_string(),
+            source: e.from,
+            target: e.to,
+            relation_type: e.relation,
+            weight: e.weight as f32,
+            confidence_score: e.weight as f32,
+            provenance_id: "unknown".to_string(),
+            contradicts_edge_id: None,
+            is_inferred: false,
+            source_language: None,
+            target_language: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+}
+
+impl From<crate::context::belief_graph::PersistedBeliefGraph> for BeliefGraph {
+    fn from(p: crate::context::belief_graph::PersistedBeliefGraph) -> Self {
+        let nodes = p.nodes.into_iter().map(|(k, v)| (k, BeliefNode::from(v))).collect();
+        let edges = p.edges.into_iter().map(BeliefEdge::from).collect();
+        Self { nodes, edges }
+    }
+}
+
+impl From<BeliefGraph> for crate::context::belief_graph::PersistedBeliefGraph {
+    fn from(g: BeliefGraph) -> Self {
+        let nodes = g.nodes.into_iter().map(|(k, v)| (k, crate::domain::belief::BeliefNode::from(v))).collect();
+        let edges = g.edges.into_iter().map(crate::domain::belief::BeliefEdge::from).collect();
+        Self { nodes, edges }
+    }
+}

--- a/gestalt_core/src/domain/mod.rs
+++ b/gestalt_core/src/domain/mod.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 pub mod belief;
+pub mod belief_graph;
 pub mod error;
 pub mod genui;
 pub mod rag;

--- a/gestalt_core/tests/belief_graph_test.rs
+++ b/gestalt_core/tests/belief_graph_test.rs
@@ -1,0 +1,127 @@
+// describe: BeliefGraph Core Domain Tests
+// it("should allow adding nodes and clamping belief scores")
+// it("should support adding edges, verifying weights, and retrieving neighbors")
+// it("should support exporting JSON and performing import round-trips")
+// it("should seamlessly convert to and from context persisted graphs")
+
+use gestalt_core::domain::belief_graph::BeliefGraph;
+use gestalt_core::context::belief_graph::PersistedBeliefGraph;
+
+#[test]
+fn test_domain_node_addition_and_clamping() {
+    let mut graph = BeliefGraph::new();
+
+    // Test normal addition
+    graph.add_node("node_1", "Concept 1", 0.8);
+    let node = graph.get_node("node_1").expect("Node should exist");
+    assert_eq!(node.id, "node_1");
+    assert_eq!(node.label, "Concept 1");
+    assert!((node.belief - 0.8).abs() < 1e-9);
+
+    // Test belief upper clamping
+    graph.add_node("node_2", "Concept 2", 1.5);
+    let node_2 = graph.get_node("node_2").unwrap();
+    assert!((node_2.belief - 1.0).abs() < 1e-9);
+
+    // Test belief lower clamping
+    graph.add_node("node_3", "Concept 3", -0.5);
+    let node_3 = graph.get_node("node_3").unwrap();
+    assert!((node_3.belief - 0.0).abs() < 1e-9);
+
+    // Test update belief
+    let success = graph.update_belief("node_1", 0.4);
+    assert!(success);
+    let updated_node = graph.get_node("node_1").unwrap();
+    assert!((updated_node.belief - 0.4).abs() < 1e-9);
+
+    // Test update non-existent node
+    let fail = graph.update_belief("non_existent", 0.5);
+    assert!(!fail);
+}
+
+#[test]
+fn test_domain_edge_and_neighbors() {
+    let mut graph = BeliefGraph::new();
+
+    graph.add_node("A", "Alpha", 1.0);
+    graph.add_node("B", "Beta", 0.9);
+    graph.add_node("C", "Gamma", 0.8);
+
+    graph.add_edge("A", "B", 0.75, "leads_to");
+    graph.add_edge("A", "C", 0.5, "supports");
+
+    let neighbors_a = graph.neighbors("A");
+    assert_eq!(neighbors_a.len(), 2);
+    assert!(neighbors_a.contains(&"B".to_string()));
+    assert!(neighbors_a.contains(&"C".to_string()));
+
+    let edge_1 = &graph.edges[0];
+    assert_eq!(edge_1.from, "A");
+    assert_eq!(edge_1.to, "B");
+    assert!((edge_1.weight - 0.75).abs() < 1e-9);
+    assert_eq!(edge_1.relation, "leads_to");
+}
+
+#[test]
+fn test_domain_json_export_roundtrip() {
+    let mut graph = BeliefGraph::new();
+    graph.add_node("node_a", "Node A", 0.9);
+    graph.add_node("node_b", "Node B", 0.7);
+    graph.add_edge("node_a", "node_b", 0.85, "depends_on");
+
+    let exported_val = graph.export_json();
+    assert!(exported_val.is_object());
+
+    let json_str = graph.save_to_string().expect("Serialization failed");
+    let reconstructed = BeliefGraph::load_from_string(&json_str).expect("Deserialization failed");
+
+    assert_eq!(reconstructed.nodes.len(), 2);
+    assert_eq!(reconstructed.edges.len(), 1);
+
+    let node_a = reconstructed.get_node("node_a").unwrap();
+    assert_eq!(node_a.label, "Node A");
+    assert!((node_a.belief - 0.9).abs() < 1e-9);
+
+    let edge = &reconstructed.edges[0];
+    assert_eq!(edge.from, "node_a");
+    assert_eq!(edge.to, "node_b");
+    assert!((edge.weight - 0.85).abs() < 1e-9);
+    assert_eq!(edge.relation, "depends_on");
+}
+
+#[test]
+fn test_interop_conversions() {
+    let mut domain_graph = BeliefGraph::new();
+    domain_graph.add_node("n1", "Concept One", 0.9);
+    domain_graph.add_edge("n1", "n2", 0.8, "related_to");
+
+    // Convert to context persisted graph
+    let persisted: PersistedBeliefGraph = domain_graph.clone().into();
+    assert_eq!(persisted.nodes.len(), 1);
+    assert_eq!(persisted.edges.len(), 1);
+
+    let context_node = persisted.nodes.get("n1").unwrap();
+    assert_eq!(context_node.concept, "Concept One");
+    assert!((context_node.confidence - 0.9).abs() < 1e-6);
+
+    let context_edge = &persisted.edges[0];
+    assert_eq!(context_edge.source, "n1");
+    assert_eq!(context_edge.target, "n2");
+    assert_eq!(context_edge.relation_type, "related_to");
+    assert!((context_edge.weight - 0.8).abs() < 1e-6);
+
+    // Convert back from context persisted graph
+    let back_graph = BeliefGraph::from(persisted);
+    assert_eq!(back_graph.nodes.len(), 1);
+    assert_eq!(back_graph.edges.len(), 1);
+
+    let back_node = back_graph.get_node("n1").unwrap();
+    assert_eq!(back_node.label, "Concept One");
+    assert!((back_node.belief - 0.9).abs() < 1e-6);
+
+    let back_edge = &back_graph.edges[0];
+    assert_eq!(back_edge.from, "n1");
+    assert_eq!(back_edge.to, "n2");
+    assert_eq!(back_edge.relation, "related_to");
+    assert!((back_edge.weight - 0.8).abs() < 1e-6);
+}


### PR DESCRIPTION
Implements the BeliefGraph core in the domain layer, registering it in mod.rs, adding detailed integration tests, and integrating with the existing context-level persistence.

Fixes #536

---
*PR created automatically by Jules for task [12589810844979686442](https://jules.google.com/task/12589810844979686442) started by @iberi22*