### PR TITLE
feat(cli): gestalt doctor, --version, and CI search-tests visibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
           cargo test -p gestalt-state --all-targets
           cargo test -p gestalt-ws --all-targets
 
+      - name: Cargo Test (Search)
+        run: cargo test -p gestalt-search --all-targets
+
       - name: Cargo Check (Other packages)
         run: |
           cargo check \

--- a/gestalt_cli/src/main.rs
+++ b/gestalt_cli/src/main.rs
@@ -25,6 +25,7 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 use ulid::Ulid;
 
 // gestalt-router types
+use gestalt_core::application::agent::registry::AgentRegistry;
 use gestalt_core::application::agent::xavier::XavierClient;
 use gestalt_router::agent::SubprocessRunner;
 use gestalt_router::router::Router;
@@ -216,6 +217,7 @@ impl Default for AdapterRegistry {
 /// CLI arguments
 #[derive(Parser, Debug)]
 #[command(name = "gestalt")]
+#[command(version)]
 #[command(about = "OpenClaw ↔ Gestalt Bridge CLI", long_about = None)]
 struct Args {
     #[command(subcommand)]
@@ -245,6 +247,9 @@ enum Commands {
 
     /// Check server status
     Status,
+
+    /// Check environment sanity (doctor check)
+    Doctor,
 
     /// List available tools
     Tools,
@@ -803,6 +808,75 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     println!("📍 {}", url);
                     std::process::exit(1);
                 },
+            }
+        },
+
+        Commands::Doctor => {
+            println!("🔍 Running Gestalt Doctor Environment Check...");
+            println!("=============================================");
+            let mut all_healthy = true;
+
+            // 1. Xavier Reachability Check
+            let xavier_client = XavierClient::from_env();
+            match xavier_client.health().await {
+                Ok(_) => {
+                    println!("✅ Xavier reachability: Healthy (endpoint: {})", xavier_client.endpoint);
+                }
+                Err(e) => {
+                    println!("❌ Xavier reachability: Unreachable (endpoint: {}): {}", xavier_client.endpoint, e);
+                    all_healthy = false;
+                }
+            }
+
+            // 2. StateDb Open Check
+            let db_path = home::home_dir()
+                .unwrap_or_else(|| std::path::PathBuf::from("."))
+                .join(".gestalt")
+                .join("state.db");
+            match StateDb::open(&db_path) {
+                Ok(_) => {
+                    println!("✅ StateDb open: Success (path: {})", db_path.display());
+                }
+                Err(e) => {
+                    println!("❌ StateDb open: Failed (path: {}): {}", db_path.display(), e);
+                    all_healthy = false;
+                }
+            }
+
+            // 3. Agent Registry Check
+            let registry_path = std::path::Path::new("agent-registry.toml");
+            match AgentRegistry::load(registry_path) {
+                Ok(reg) => {
+                    println!("✅ Agent registry parse: Success ({} agents loaded)", reg.agents.len());
+                }
+                Err(e) => {
+                    println!("❌ Agent registry parse: Failed to load: {}", e);
+                    all_healthy = false;
+                }
+            }
+
+            // 4. Bus Serve Reachability Check
+            use std::net::TcpStream;
+            match TcpStream::connect_timeout(
+                &"127.0.0.1:8081".parse().unwrap(),
+                Duration::from_secs(2),
+            ) {
+                Ok(_) => {
+                    println!("✅ Bus serve reachability: Reachable (port 8081)");
+                }
+                Err(e) => {
+                    println!("❌ Bus serve reachability: Unreachable (port 8081): {}", e);
+                    all_healthy = false;
+                }
+            }
+
+            println!("=============================================");
+            if all_healthy {
+                println!("Verdict: Healthy! All environment components are fully operational.");
+                std::process::exit(0);
+            } else {
+                println!("Verdict: Unhealthy! Some environment checks failed. Please review the ❌ items above.");
+                std::process::exit(1);
             }
         },
 

--- a/gestalt_cli/tests/cli_tests.rs
+++ b/gestalt_cli/tests/cli_tests.rs
@@ -39,3 +39,39 @@ fn test_status_offline() {
     // But we know it should return an error.
     assert!(!combined.is_empty());
 }
+
+#[test]
+fn test_version_flag() {
+    let bin_path = env!("CARGO_BIN_EXE_gestalt_cli");
+    let output = Command::new(bin_path)
+        .arg("--version")
+        .output()
+        .expect("Failed to execute command");
+
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let expected = format!("gestalt {}", env!("CARGO_PKG_VERSION"));
+    assert!(stdout.contains(&expected));
+}
+
+#[test]
+fn test_doctor_command() {
+    let bin_path = env!("CARGO_BIN_EXE_gestalt_cli");
+    let output = Command::new(bin_path)
+        .arg("doctor")
+        .output()
+        .expect("Failed to execute command");
+
+    // The doctor command might succeed or fail depending on if services are offline/online.
+    // That's fine, but let's check that the output contains the diagnostic checks we implemented!
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{}{}", stdout, stderr);
+
+    assert!(combined.contains("Running Gestalt Doctor Environment Check"));
+    assert!(combined.contains("Xavier reachability"));
+    assert!(combined.contains("StateDb open"));
+    assert!(combined.contains("Agent registry parse"));
+    assert!(combined.contains("Bus serve reachability"));
+    assert!(combined.contains("Verdict:"));
+}


### PR DESCRIPTION
### Wave-9 Integration Note

This pull request completes the final integration pass for Wave 9, bridging CLI operations, environment diagnostics, and CI visibility.

#### Merged Wave-9 Issues
1. **Wave-9 Issue 1 (Search Regressions):** Integrated `gestalt-search` tests directly into the GitHub Actions CI workflow to ensure search regressions do not pass silently.
2. **Wave-9 Issue 3 (Observer Hook Injectors):** Merge-safe configuration injectors for external agents (Codex, Claude, Opencode) are fully functional.
3. **Wave-9 Issue 5 (Orca Bridge):** Orca agent-hooks bridge is running with automatic status mapping and fallbacks.
4. **Wave-9 Issue 7 (Swarm Metrics & Durability):** Pre-warmed agent pool and fd-lock metrics persistence are fully integrated.
5. **Wave-9 Issue 9 (Thinking Gating):** Gated insight synthesis with minimum execution thresholds is fully wired.
6. **Wave-9 Issue 12 (This Issue):** Handled top-level `--version` derivation from Cargo.toml and created the `gestalt doctor` command to check environment diagnostics.

#### Remaining Gaps
- Further performance tuning on parallel container/VFS sandboxing under low-resource environments.
- Direct visualization of event bus streams via a unified dashboard.

Fixes #544

---
*PR created automatically by Jules for task [4226883233945216517](https://jules.google.com/task/4226883233945216517) started by @iberi22*