### PR TITLE
feat: declarative TOML spec for agent chains (on_event chaining)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2011,6 +2011,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
  "ulid",

--- a/gestalt_cli/Cargo.toml
+++ b/gestalt_cli/Cargo.toml
@@ -26,4 +26,5 @@ gestalt-state = { path = "../gestalt-state" }
 gestalt-search = { path = "../gestalt-search" }
 uuid = { version = "1.15", features = ["v4", "serde"] }
 axum = "0.8"
+toml = "0.8"
 tempfile = "3.24"

--- a/gestalt_cli/src/agent_wrapper.rs
+++ b/gestalt_cli/src/agent_wrapper.rs
@@ -134,6 +134,14 @@ impl AgentWrapper {
     /// 5. Applies each edit to the underlying [`VirtualFS`].
     /// 6. Returns the list of edits (may be empty if nothing changed).
     pub async fn execute(&self) -> Result<Vec<BlockEdit>, String> {
+        self.execute_with_output().await.map(|(edits, _, _, _)| edits)
+    }
+
+    /// Run the agent and capture its diffs, exit status, stdout, and stderr.
+    ///
+    /// Extends [`execute`](Self::execute) to return the raw process output and status
+    /// for chaining and failure checking.
+    pub async fn execute_with_output(&self) -> Result<(Vec<BlockEdit>, std::process::ExitStatus, String, String), String> {
         let start = std::time::Instant::now();
         info!(
             agent_id = %self.agent_id,
@@ -200,7 +208,7 @@ impl AgentWrapper {
             "AgentWrapper completed",
         );
 
-        Ok(edits)
+        Ok((edits, output.status, stdout, stderr))
     }
 
     /// Apply a single [`BlockEdit`] to the [`VirtualFS`].

--- a/gestalt_cli/src/chain.rs
+++ b/gestalt_cli/src/chain.rs
@@ -1,0 +1,328 @@
+//! Declarative TOML spec parsing and topological execution for agent chains
+//!
+//! Implements `gestalt chain run --spec pipeline.toml` sequential pipelines.
+
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, VecDeque};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tracing::{error, info, warn};
+
+use gestalt_router::event_bus::{BusEvent, handle_event};
+use gestalt_state::StateDb;
+use crate::agent_wrapper::{AgentWrapper, InMemoryVfs, BlockEdit};
+
+/// Default event to trigger subsequent steps
+fn default_on_event() -> String {
+    "run_finished".to_string()
+}
+
+/// A single step in the pipeline chain
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChainStep {
+    /// Unique name of this step
+    pub name: String,
+    /// Agent to execute (e.g. "opencode", "codex")
+    pub agent: String,
+    /// Task description to pass to the agent
+    pub task: String,
+    /// Event type that triggers this step (defaults to "run_finished")
+    #[serde(default = "default_on_event")]
+    pub on_event: String,
+    /// Dependencies on prior steps (by name)
+    #[serde(default)]
+    pub requires: Vec<String>,
+}
+
+/// Declarative TOML pipeline specification
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChainSpec {
+    /// Ordered or unordered steps list to be topologically sorted
+    pub steps: Vec<ChainStep>,
+}
+
+/// Sort steps topologically based on their `requires` dependencies.
+/// Detects missing dependencies and circular dependency cycles.
+pub fn topological_sort(steps: &[ChainStep]) -> Result<Vec<ChainStep>, String> {
+    let mut steps_map: HashMap<String, &ChainStep> = HashMap::new();
+    for step in steps {
+        if steps_map.insert(step.name.clone(), step).is_some() {
+            return Err(format!("Duplicate step name '{}' in specification", step.name));
+        }
+    }
+
+    // Verify all dependency references exist
+    for step in steps {
+        for req in &step.requires {
+            if !steps_map.contains_key(req) {
+                return Err(format!(
+                    "Step '{}' requires undefined step '{}'",
+                    step.name, req
+                ));
+            }
+        }
+    }
+
+    // Kahn's algorithm setup
+    let mut in_degree: HashMap<String, usize> = HashMap::new();
+    let mut adjacency: HashMap<String, Vec<String>> = HashMap::new();
+
+    for step in steps {
+        in_degree.insert(step.name.clone(), step.requires.len());
+        for req in &step.requires {
+            adjacency
+                .entry(req.clone())
+                .or_default()
+                .push(step.name.clone());
+        }
+    }
+
+    let mut queue: VecDeque<String> = steps
+        .iter()
+        .filter(|s| s.requires.is_empty())
+        .map(|s| s.name.clone())
+        .collect();
+
+    let mut sorted_names = Vec::new();
+
+    while let Some(node) = queue.pop_front() {
+        sorted_names.push(node.clone());
+        if let Some(neighbors) = adjacency.get(&node) {
+            for neighbor in neighbors {
+                if let Some(deg) = in_degree.get_mut(neighbor) {
+                    *deg -= 1;
+                    if *deg == 0 {
+                        queue.push_back(neighbor.clone());
+                    }
+                }
+            }
+        }
+    }
+
+    if sorted_names.len() != steps.len() {
+        return Err("Circular dependency or cycle detected in step requirements".to_string());
+    }
+
+    // Map names back to cloned ChainSteps
+    let mut sorted_steps = Vec::new();
+    for name in sorted_names {
+        if let Some(step) = steps_map.get(&name) {
+            sorted_steps.push((*step).clone());
+        }
+    }
+
+    Ok(sorted_steps)
+}
+
+/// Execute a declarative pipeline chain of agents sequentially in topological order.
+pub async fn run_chain(
+    spec_path: &str,
+    project: Option<String>,
+    continue_on_error: bool,
+) -> Result<(), String> {
+    info!("Loading chain specification from {}", spec_path);
+    let content = fs::read_to_string(spec_path)
+        .map_err(|e| format!("Failed to read spec file '{}': {}", spec_path, e))?;
+
+    let spec: ChainSpec = toml::from_str(&content)
+        .map_err(|e| format!("Failed to parse TOML specification: {}", e))?;
+
+    if spec.steps.is_empty() {
+        return Err("No steps specified in the pipeline".to_string());
+    }
+
+    let sorted_steps = topological_sort(&spec.steps)?;
+    info!(
+        "Topological sort successful. Execution order: {:?}",
+        sorted_steps.iter().map(|s| &s.name).collect::<Vec<_>>()
+    );
+
+    // Shared chain run ID
+    let shared_run_id = uuid::Uuid::new_v4().to_string();
+    let proj_name = project.unwrap_or_else(|| "default".to_string());
+
+    // Connect to local StateDb for durable event persistence
+    let db_path = home::home_dir()
+        .unwrap_or_else(|| PathBuf::from("."))
+        .join(".gestalt")
+        .join("state.db");
+
+    let db = Arc::new(
+        StateDb::open(&db_path)
+            .map_err(|e| format!("Failed to open StateDb at {}: {}", db_path.display(), e))?,
+    );
+
+    let sink = std::env::var("XAVIER_TOKEN")
+        .ok()
+        .filter(|t| !t.is_empty())
+        .map(|_| gestalt_router::xavier_sink::XavierEventSink::from_env());
+
+    let mut any_step_failed = false;
+
+    for step in sorted_steps {
+        info!("Executing step '{}' using agent '{}'", step.name, step.agent);
+
+        // 1. Emit `run_started` event on the universal event bus
+        let start_ev = BusEvent::new(
+            &step.agent,
+            "run_started",
+            format!("Step '{}' (agent: '{}') started: {}", step.name, step.agent, step.task),
+        )
+        .with_run_id(&shared_run_id)
+        .with_project(&proj_name)
+        .with_state("Running");
+
+        if let Err(e) = handle_event(&db, &start_ev, sink.as_ref()).await {
+            warn!("Failed to emit run_started event to bus: {}", e);
+        }
+
+        // 2. Set up InMemoryVfs for the agent wrapper
+        let vfs = Arc::new(InMemoryVfs::new());
+        let command_str = format!("{} {}", step.agent, step.task);
+
+        let wrapper = AgentWrapper::new(
+            vfs.clone(),
+            step.agent.clone(),
+            shared_run_id.clone(),
+            command_str,
+        );
+
+        // 3. Execute step using AgentWrapper (with captured exit status, stdout, stderr)
+        let execution_result = wrapper.execute_with_output().await;
+
+        match execution_result {
+            Ok((edits, status, stdout, stderr)) => {
+                if status.success() {
+                    info!("Step '{}' finished successfully.", step.name);
+
+                    // Emit `run_finished` success event
+                    let finish_ev = BusEvent::new(
+                        &step.agent,
+                        "run_finished",
+                        format!("Step '{}' finished successfully", step.name),
+                    )
+                    .with_run_id(&shared_run_id)
+                    .with_project(&proj_name)
+                    .with_state("Success");
+
+                    if let Err(e) = handle_event(&db, &finish_ev, sink.as_ref()).await {
+                        warn!("Failed to emit run_finished success event to bus: {}", e);
+                    }
+
+                    // Append output summary to next step's XAVIER_CONTEXT
+                    let summary = build_output_summary(&step.name, &stdout, &edits);
+                    append_to_xavier_context(&summary);
+                } else {
+                    error!(
+                        "Step '{}' command failed with non-zero status. Stderr: {}",
+                        step.name, stderr
+                    );
+                    any_step_failed = true;
+
+                    // Emit `run_finished` failed event
+                    let fail_ev = BusEvent::new(
+                        &step.agent,
+                        "run_finished",
+                        format!("Step '{}' failed with status: {:?}", step.name, status),
+                    )
+                    .with_run_id(&shared_run_id)
+                    .with_project(&proj_name)
+                    .with_state("Crashed");
+
+                    if let Err(e) = handle_event(&db, &fail_ev, sink.as_ref()).await {
+                        warn!("Failed to emit run_finished failed event to bus: {}", e);
+                    }
+
+                    if !continue_on_error {
+                        return Err(format!(
+                            "Chain halted. Step '{}' failed with status: {:?}",
+                            step.name, status
+                        ));
+                    }
+                }
+            }
+            Err(err_msg) => {
+                error!("Step '{}' execution error: {}", step.name, err_msg);
+                any_step_failed = true;
+
+                // Emit failed event on VFS or wrapper execution error
+                let fail_ev = BusEvent::new(
+                    &step.agent,
+                    "run_finished",
+                    format!("Step '{}' execution error: {}", step.name, err_msg),
+                )
+                .with_run_id(&shared_run_id)
+                .with_project(&proj_name)
+                .with_state("Crashed");
+
+                if let Err(e) = handle_event(&db, &fail_ev, sink.as_ref()).await {
+                    warn!("Failed to emit run_finished failed event to bus: {}", e);
+                }
+
+                if !continue_on_error {
+                    return Err(format!("Chain halted. Step '{}' failed: {}", step.name, err_msg));
+                }
+            }
+        }
+    }
+
+    if any_step_failed {
+        Err("One or more steps in the chain failed to execute successfully".to_string())
+    } else {
+        Ok(())
+    }
+}
+
+/// Helper to format a rich output summary from stdout or parsed edits.
+fn build_output_summary(step_name: &str, stdout: &str, edits: &[BlockEdit]) -> String {
+    let mut summary = format!("=== Step '{}' Output ===\n", step_name);
+    if !stdout.trim().is_empty() {
+        summary.push_str(stdout.trim());
+        summary.push('\n');
+    }
+
+    if !edits.is_empty() {
+        summary.push_str("VFS Edits applied:\n");
+        for edit in edits {
+            match edit {
+                BlockEdit::Insert { path, line, .. } => {
+                    summary.push_str(&format!(" - Inserted lines in {path} at line {line}\n"));
+                }
+                BlockEdit::Delete { path, line } => {
+                    summary.push_str(&format!(" - Deleted line in {path} at line {line}\n"));
+                }
+                BlockEdit::Replace { path, line, .. } => {
+                    summary.push_str(&format!(" - Replaced content in {path} at line {line}\n"));
+                }
+            }
+        }
+    }
+
+    if stdout.trim().is_empty() && edits.is_empty() {
+        summary.push_str("Execution completed with no printed output or VFS edits.\n");
+    }
+
+    summary
+}
+
+/// Safely append an output summary to the XAVIER_CONTEXT JSON list.
+fn append_to_xavier_context(summary: &str) {
+    let mut context_list: Vec<String> = if let Ok(existing) = std::env::var("XAVIER_CONTEXT") {
+        serde_json::from_str(&existing).unwrap_or_else(|_| {
+            if !existing.trim().is_empty() {
+                vec![existing]
+            } else {
+                vec![]
+            }
+        })
+    } else {
+        vec![]
+    };
+
+    context_list.push(summary.to_string());
+
+    if let Ok(new_context) = serde_json::to_string(&context_list) {
+        std::env::set_var("XAVIER_CONTEXT", new_context);
+    }
+}

--- a/gestalt_cli/src/main.rs
+++ b/gestalt_cli/src/main.rs
@@ -4,6 +4,7 @@
 
 mod agent_wrapper;
 mod bus;
+mod chain;
 mod config;
 mod observe;
 mod repl;
@@ -424,6 +425,30 @@ enum Commands {
         /// Run discovery once and exit
         #[arg(long)]
         once: bool,
+    },
+
+    /// Run a chain of agents sequentially in dependency order
+    Chain {
+        #[command(subcommand)]
+        action: ChainAction,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+enum ChainAction {
+    /// Run a chain specification
+    Run {
+        /// Path to the TOML specification file
+        #[arg(long)]
+        spec: String,
+
+        /// Optional project name
+        #[arg(long)]
+        project: Option<String>,
+
+        /// Continue executing subsequent steps even if a step fails
+        #[arg(long)]
+        continue_on_error: bool,
     },
 }
 
@@ -1996,6 +2021,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
             } else {
                 observe::run_daemon_loop().await?;
+            }
+        },
+
+        Commands::Chain { action } => match action {
+            ChainAction::Run {
+                spec,
+                project,
+                continue_on_error,
+            } => {
+                info!("Starting chain run for spec: {}", spec);
+                println!("⛓️  Running agent pipeline chain...");
+                if let Err(e) = chain::run_chain(&spec, project, continue_on_error).await {
+                    error!("Chain run failed: {}", e);
+                    eprintln!("❌ Chain run failed: {}", e);
+                    std::process::exit(1);
+                }
+                println!("✅ Chain run completed successfully.");
             }
         },
     }

--- a/gestalt_cli/tests/chain_test.rs
+++ b/gestalt_cli/tests/chain_test.rs
@@ -1,0 +1,216 @@
+//! Integration tests for the agent pipeline chaining functionality
+//!
+//! describe: This test module verifies TOML spec parsing, topological sorting,
+//! sequential execution, event emission, and environment context propagation.
+//!
+//! it("should topologically sort dependencies and detect cycles"):
+//! it("should execute mock steps in correct order"):
+//! it("should propagate exit failures and continue on error when specified"):
+
+#[path = "../src/agent_wrapper.rs"]
+pub mod agent_wrapper;
+
+#[path = "../src/chain.rs"]
+pub mod chain;
+
+use chain::{topological_sort, run_chain, ChainStep};
+use std::fs;
+use std::sync::{Mutex, OnceLock};
+use tempfile::tempdir;
+
+static TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Thread safety guard that serializes test execution and isolates env variables.
+struct EnvGuard {
+    _lock: std::sync::MutexGuard<'static, ()>,
+    old_home: Option<std::ffi::OsString>,
+    old_xavier: Option<std::ffi::OsString>,
+}
+
+impl EnvGuard {
+    fn new(temp_home: &std::path::Path) -> Self {
+        let lock = TEST_MUTEX.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let old_home = std::env::var_os("HOME");
+        let old_xavier = std::env::var_os("XAVIER_CONTEXT");
+
+        std::env::set_var("HOME", temp_home);
+        std::env::remove_var("XAVIER_CONTEXT");
+
+        Self {
+            _lock: lock,
+            old_home,
+            old_xavier,
+        }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        if let Some(ref h) = self.old_home {
+            std::env::set_var("HOME", h);
+        } else {
+            std::env::remove_var("HOME");
+        }
+        if let Some(ref x) = self.old_xavier {
+            std::env::set_var("XAVIER_CONTEXT", x);
+        } else {
+            std::env::remove_var("XAVIER_CONTEXT");
+        }
+    }
+}
+
+#[test]
+fn test_describe_topological_sort_success() {
+    // it("should sort independent steps and simple dependent steps correctly")
+    let steps = vec![
+        ChainStep {
+            name: "implement".to_string(),
+            agent: "codex".to_string(),
+            task: "implement research".to_string(),
+            on_event: "run_finished".to_string(),
+            requires: vec!["scout".to_string()],
+        },
+        ChainStep {
+            name: "scout".to_string(),
+            agent: "opencode".to_string(),
+            task: "research problem".to_string(),
+            on_event: "run_finished".to_string(),
+            requires: vec![],
+        },
+    ];
+
+    let sorted = topological_sort(&steps).expect("Should sort successfully");
+    assert_eq!(sorted.len(), 2);
+    assert_eq!(sorted[0].name, "scout");
+    assert_eq!(sorted[1].name, "implement");
+}
+
+#[test]
+fn test_describe_topological_sort_missing_dependency() {
+    // it("should fail if a required dependency is missing")
+    let steps = vec![ChainStep {
+        name: "implement".to_string(),
+        agent: "codex".to_string(),
+        task: "implement".to_string(),
+        on_event: "run_finished".to_string(),
+        requires: vec!["missing_step".to_string()],
+    }];
+
+    let err = topological_sort(&steps).unwrap_err();
+    assert!(err.contains("requires undefined step"));
+}
+
+#[test]
+fn test_describe_topological_sort_cycle_detected() {
+    // it("should fail if there is a circular dependency loop")
+    let steps = vec![
+        ChainStep {
+            name: "step_a".to_string(),
+            agent: "agent".to_string(),
+            task: "task".to_string(),
+            on_event: "run_finished".to_string(),
+            requires: vec!["step_b".to_string()],
+        },
+        ChainStep {
+            name: "step_b".to_string(),
+            agent: "agent".to_string(),
+            task: "task".to_string(),
+            on_event: "run_finished".to_string(),
+            requires: vec!["step_a".to_string()],
+        },
+    ];
+
+    let err = topological_sort(&steps).unwrap_err();
+    assert!(err.contains("Circular dependency or cycle detected"));
+}
+
+#[tokio::test]
+async fn test_it_executes_mock_chain_success() {
+    // it("should execute mock steps sequentially and propagate summaries forward")
+    let dir = tempdir().expect("Failed to create temp dir");
+    let _guard = EnvGuard::new(dir.path());
+    let spec_path = dir.path().join("pipeline.toml");
+
+    let spec_content = r#"
+[[steps]]
+name = "step1"
+agent = "echo"
+task = "hello_from_step1"
+
+[[steps]]
+name = "step2"
+agent = "echo"
+task = "hello_from_step2"
+requires = ["step1"]
+"#;
+
+    fs::write(&spec_path, spec_content).expect("Failed to write temp spec");
+
+    let result = run_chain(spec_path.to_str().unwrap(), Some("test-project".to_string()), false).await;
+    assert!(result.is_ok(), "Chain execution failed: {:?}", result);
+
+    // Verify context propagation
+    let xavier_ctx = std::env::var("XAVIER_CONTEXT").expect("XAVIER_CONTEXT should be set");
+    assert!(xavier_ctx.contains("hello_from_step1"), "Should contain output of step1");
+    assert!(xavier_ctx.contains("hello_from_step2"), "Should contain output of step2");
+}
+
+#[tokio::test]
+async fn test_it_halts_chain_on_error() {
+    // it("should stop the chain when a step exits with a non-zero status")
+    let dir = tempdir().expect("Failed to create temp dir");
+    let _guard = EnvGuard::new(dir.path());
+    let spec_path = dir.path().join("pipeline.toml");
+
+    // "false" is a standard Unix command that exits with code 1
+    let spec_content = r#"
+[[steps]]
+name = "fail_step"
+agent = "false"
+task = ""
+
+[[steps]]
+name = "subsequent_step"
+agent = "echo"
+task = "should_not_run"
+requires = ["fail_step"]
+"#;
+
+    fs::write(&spec_path, spec_content).expect("Failed to write temp spec");
+
+    let result = run_chain(spec_path.to_str().unwrap(), Some("test-project".to_string()), false).await;
+    assert!(result.is_err(), "Chain should have failed");
+    let err_msg = result.unwrap_err();
+    assert!(err_msg.contains("Chain halted") || err_msg.contains("failed"));
+}
+
+#[tokio::test]
+async fn test_it_continues_on_error_when_flag_enabled() {
+    // it("should execute subsequent steps even if an intermediate step fails when continue_on_error is true")
+    let dir = tempdir().expect("Failed to create temp dir");
+    let _guard = EnvGuard::new(dir.path());
+    let spec_path = dir.path().join("pipeline.toml");
+
+    let spec_content = r#"
+[[steps]]
+name = "fail_step"
+agent = "false"
+task = ""
+
+[[steps]]
+name = "ok_step"
+agent = "echo"
+task = "hello_after_failure"
+"#;
+
+    fs::write(&spec_path, spec_content).expect("Failed to write temp spec");
+
+    let result = run_chain(spec_path.to_str().unwrap(), Some("test-project".to_string()), true).await;
+    assert!(result.is_err(), "Overall chain should still return Err at the end due to a failed step");
+    let err_msg = result.unwrap_err();
+    assert!(err_msg.contains("failed to execute successfully"), "Expected failure summary, got: {}", err_msg);
+
+    // Verify context propagation of the successful step (indicating it ran even after the failure)
+    let xavier_ctx = std::env::var("XAVIER_CONTEXT").expect("XAVIER_CONTEXT should be set");
+    assert!(xavier_ctx.contains("hello_after_failure"), "The successful step should have executed");
+}


### PR DESCRIPTION
Implemented a declarative TOML agent chaining specification as part of wave-9 feat-router-mvp. Supports sequential step dependency resolution via Kahn's algorithm, automated step event logging, exit status/output capturing in AgentWrapper, and XAVIER_CONTEXT summary feeding to subsequent steps. Verified using comprehensive integration tests.

Fixes #541

---
*PR created automatically by Jules for task [3648654738370373203](https://jules.google.com/task/3648654738370373203) started by @iberi22*