### PR TITLE
feat(cli): gestalt agent exec thin launcher

### DIFF
--- a/gestalt_cli/src/agent_wrapper.rs
+++ b/gestalt_cli/src/agent_wrapper.rs
@@ -215,6 +215,194 @@ impl AgentWrapper {
         Ok((edits, output.status, stdout, stderr))
     }
 
+    /// Run the agent command with full PRE -> RUN -> POST lifecycle and bus tracking.
+    pub async fn execute_with_trace(
+        &self,
+        task: &str,
+        project: Option<&str>,
+        timeout_secs: Option<u64>,
+    ) -> Result<(Vec<BlockEdit>, std::process::ExitStatus, String, String), String> {
+        let start = std::time::Instant::now();
+        let proj = project.unwrap_or("default");
+
+        // 1. PRE: XavierClient::search(task) → build XAVIER_CONTEXT env
+        let xavier = gestalt_core::application::agent::xavier::XavierClient::from_env();
+        let search_results = xavier.search_context(task, 5).await;
+        let xavier_context = serde_json::to_string(&search_results).unwrap_or_else(|_| "[]".to_string());
+
+        // 2. Open StateDb
+        let db_path = home::home_dir()
+            .unwrap_or_else(|| std::path::PathBuf::from("."))
+            .join(".gestalt")
+            .join("state.db");
+
+        // Ensure parent directories exist
+        if let Some(parent) = db_path.parent() {
+            let _ = std::fs::create_dir_all(parent);
+        }
+
+        let db = std::sync::Arc::new(
+            gestalt_state::statedb::StateDb::open(&db_path)
+                .map_err(|e| format!("Failed to open StateDb: {}", e))?,
+        );
+
+        // 3. Emit run_started BusEvent
+        let start_summary = format!("Agent '{}' execution started for task: {}", self.agent_id, task);
+        let start_ev = gestalt_router::event_bus::BusEvent::new(&self.agent_id, "run_started", &start_summary)
+            .with_run_id(&self.run_id)
+            .with_project(proj)
+            .with_state("Running")
+            .with_metadata(serde_json::json!({
+                "task": task,
+                "command": self.command,
+                "requested_by": std::env::var("GESTALT_REQUESTED_BY").unwrap_or_else(|_| "cli".into()),
+            }));
+
+        let sink = std::env::var("XAVIER_TOKEN")
+            .ok()
+            .filter(|t| !t.is_empty())
+            .map(|_| gestalt_router::xavier_sink::XavierEventSink::from_env());
+
+        if let Err(e) = gestalt_router::event_bus::handle_event(&db, &start_ev, sink.as_ref()).await {
+            warn!("Failed to emit run_started event: {}", e);
+        }
+
+        // 4. Launch the command with XAVIER_CONTEXT injected
+        let (program, args) = split_command(&self.command);
+        if program.is_empty() {
+            return Err("Empty command".to_string());
+        }
+
+        let timeout_dur = std::time::Duration::from_secs(timeout_secs.unwrap_or(300));
+
+        // Spawning using tokio process command to handle timeouts asynchronously
+        let mut cmd = tokio::process::Command::new(&program);
+        cmd.args(&args);
+        cmd.env("XAVIER_CONTEXT", &xavier_context);
+
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
+
+        let mut child = cmd.spawn().map_err(|e| format!("Failed to spawn command '{}': {}", self.command, e))?;
+
+        let mut stdout_bytes = Vec::new();
+        let mut stderr_bytes = Vec::new();
+
+        let mut stdout_pipe = child.stdout.take().unwrap();
+        let mut stderr_pipe = child.stderr.take().unwrap();
+
+        let read_stdout = tokio::io::AsyncReadExt::read_to_end(&mut stdout_pipe, &mut stdout_bytes);
+        let read_stderr = tokio::io::AsyncReadExt::read_to_end(&mut stderr_pipe, &mut stderr_bytes);
+        let wait_child = child.wait();
+
+        let timeout_fut = tokio::time::sleep(timeout_dur);
+
+        let run_res = tokio::select! {
+            res = async {
+                tokio::try_join!(read_stdout, read_stderr, wait_child)
+            } => {
+                match res {
+                    Ok((_, _, exit_status)) => {
+                        let stdout_str = String::from_utf8_lossy(&stdout_bytes).into_owned();
+                        let stderr_str = String::from_utf8_lossy(&stderr_bytes).into_owned();
+                        Ok((exit_status, stdout_str, stderr_str))
+                    }
+                    Err(e) => Err(format!("Error reading process streams: {}", e)),
+                }
+            }
+            _ = timeout_fut => {
+                let _ = child.kill().await;
+                Err("Timeout reached during execution".to_string())
+            }
+        };
+
+        let elapsed = start.elapsed();
+        let duration_ms = elapsed.as_millis() as u64;
+
+        let (status, stdout_str, stderr_str, state_str, exit_code) = match run_res {
+            Ok((exit_status, stdout, stderr)) => {
+                let state = if exit_status.success() { "Success" } else { "Crashed" };
+                (exit_status, stdout, stderr, state, exit_status.code())
+            }
+            Err(e) => {
+                // Timeout or error: obtain a non-zero exit status dynamically
+                let dummy_status = if e.contains("Timeout") {
+                    let mut dcmd = std::process::Command::new("false");
+                    let dstatus = dcmd.status().unwrap_or_else(|_| std::process::ExitStatus::default());
+                    (dstatus, String::new(), e.clone(), "Timeout", None)
+                } else {
+                    let mut dcmd = std::process::Command::new("false");
+                    let dstatus = dcmd.status().unwrap_or_else(|_| std::process::ExitStatus::default());
+                    (dstatus, String::new(), e.clone(), "Crashed", None)
+                };
+                dummy_status
+            }
+        };
+
+        // Emit run_finished BusEvent
+        let finish_summary = format!("Agent '{}' finished with state '{}' in {}ms", self.agent_id, state_str, duration_ms);
+        let finish_ev = gestalt_router::event_bus::BusEvent::new(&self.agent_id, "run_finished", &finish_summary)
+            .with_run_id(&self.run_id)
+            .with_project(proj)
+            .with_state(state_str)
+            .with_metadata(serde_json::json!({
+                "duration_ms": duration_ms,
+                "exit_code": exit_code,
+                "task": task,
+            }));
+
+        if let Err(e) = gestalt_router::event_bus::handle_event(&db, &finish_ev, sink.as_ref()).await {
+            warn!("Failed to emit run_finished event: {}", e);
+        }
+
+        // Parse unified diffs from stdout + stderr and apply to VFS
+        let edits = parse_unified_diffs(&stdout_str, &stderr_str);
+        for edit in &edits {
+            let payload = serde_json::to_string(edit).unwrap_or_else(|_| format!("{:?}", edit));
+            self.push_event("block_edit", &payload);
+
+            if let Err(e) = self.apply_edit_to_vfs(edit).await {
+                error!(
+                    path = %edit.path(),
+                    error = %e,
+                    agent_id = %self.agent_id,
+                    "Failed to apply BlockEdit to VFS",
+                );
+                return Err(format!(
+                    "Failed to apply BlockEdit for '{}': {}",
+                    edit.path(),
+                    e
+                ));
+            }
+        }
+
+        // POST: XavierClient::archive_run (kind=run_result) with the run summary
+        let run_summary_data = serde_json::json!({
+            "run_id": self.run_id,
+            "agent_id": self.agent_id,
+            "task": task,
+            "project": proj,
+            "command": self.command,
+            "state": state_str,
+            "duration_ms": duration_ms,
+            "exit_code": exit_code,
+            "edits_count": edits.len(),
+            "stdout": stdout_str,
+            "stderr": stderr_str,
+        });
+
+        let archive_content = serde_json::to_string_pretty(&run_summary_data).unwrap_or_else(|_| "{}".to_string());
+        if let Err(e) = xavier.archive_run(&archive_content, &self.run_id, serde_json::json!({
+            "run_id": self.run_id,
+            "state": state_str,
+            "duration_ms": duration_ms,
+        })).await {
+            warn!("Failed to archive run to Xavier: {}", e);
+        }
+
+        Ok((edits, status, stdout_str, stderr_str))
+    }
+
     /// Apply a single [`BlockEdit`] to the [`VirtualFS`].
     async fn apply_edit_to_vfs(&self, edit: &BlockEdit) -> Result<String, String> {
         match edit {

--- a/gestalt_cli/src/main.rs
+++ b/gestalt_cli/src/main.rs
@@ -469,6 +469,35 @@ enum Commands {
         #[command(subcommand)]
         action: ChainAction,
     },
+
+    /// Agent commands: real launcher (PRE Xavier context -> run -> bus events -> POST archive)
+    Agent {
+        #[command(subcommand)]
+        action: AgentAction,
+    },
+}
+
+// Commands::AgentExec or AgentAction represents the CLI structure for thin agent orchestration.
+#[derive(Subcommand, Debug, Clone)]
+pub enum AgentAction {
+    /// Execute an external agent with context search and bus event trace
+    Exec {
+        /// Command to execute
+        #[arg(long)]
+        agent: String,
+
+        /// Task description
+        #[arg(long)]
+        task: String,
+
+        /// Project name
+        #[arg(long)]
+        project: Option<String>,
+
+        /// Execution timeout in seconds
+        #[arg(long)]
+        timeout: Option<u64>,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -2441,6 +2470,57 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 println!("✅ Chain run completed successfully.");
             },
+        },
+
+        Commands::Agent { action } => match action {
+            AgentAction::Exec {
+                agent,
+                task,
+                project,
+                timeout,
+            } => {
+                // Determine a safe agent id by taking the first word of the command
+                let agent_id = agent
+                    .split_whitespace()
+                    .next()
+                    .unwrap_or("agent-exec")
+                    .to_string();
+                let run_id = ulid::Ulid::new().to_string();
+                let vfs = std::sync::Arc::new(agent_wrapper::InMemoryVfs::new());
+
+                let wrapper = agent_wrapper::AgentWrapper::new(
+                    vfs,
+                    agent_id,
+                    run_id,
+                    agent.clone(),
+                );
+
+                println!("🚀 Launching thin agent launcher...");
+                println!("   Command: {}", agent);
+                println!("   Task:    {}", task);
+                if let Some(ref proj) = project {
+                    println!("   Project: {}", proj);
+                }
+
+                match wrapper.execute_with_trace(&task, project.as_deref(), timeout).await {
+                    Ok((edits, status, stdout, stderr)) => {
+                        println!();
+                        println!("━━━ Run Summary ━━━");
+                        println!("Status:      {}", status);
+                        println!("VFS Edits:   {}", edits.len());
+                        println!("Stdout len:  {}", stdout.len());
+                        println!("Stderr len:  {}", stderr.len());
+                        println!("━━━━━━━━━━━━━━━━━━━");
+                        if !status.success() {
+                            std::process::exit(status.code().unwrap_or(1));
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("❌ Launcher execution failed: {}", e);
+                        std::process::exit(1);
+                    }
+                }
+            }
         },
     }
 

--- a/gestalt_cli/tests/agent_exec_test.rs
+++ b/gestalt_cli/tests/agent_exec_test.rs
@@ -1,0 +1,130 @@
+//! Integration test for thin agent launcher (gestalt agent exec)
+//!
+//! describe("thin agent launcher execution flow")
+//! it("should inject XAVIER_CONTEXT context")
+//! it("should emit run_started and run_finished bus events")
+//! it("should archive the run results to Xavier")
+
+#[path = "../src/agent_wrapper.rs"]
+mod agent_wrapper;
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::time::Duration;
+use axum::{routing::post, Json, Router};
+use agent_wrapper::{AgentWrapper, InMemoryVfs};
+use gestalt_state::statedb::StateDb;
+
+static ENV_MUTEX: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+
+fn get_env_mutex() -> &'static std::sync::Mutex<()> {
+    ENV_MUTEX.get_or_init(|| std::sync::Mutex::new(()))
+}
+
+#[tokio::test]
+async fn test_agent_exec_trace_lifecycle() {
+    // We synchronize environment modifications using our OnceLock Mutex
+    let _env_guard = get_env_mutex().lock().unwrap();
+
+    // Set up a clean temp directory for HOME to sandbox StateDb
+    let temp_home = std::env::temp_dir().join(format!("agent_exec_home_{}", uuid::Uuid::new_v4()));
+    std::fs::create_dir_all(&temp_home).unwrap();
+    let old_home = std::env::var("HOME").ok();
+    std::env::set_var("HOME", &temp_home);
+
+    // Track requests received by our mock server
+    let received_events = Arc::new(Mutex::new(Vec::<serde_json::Value>::new()));
+    let received_archives = Arc::new(Mutex::new(Vec::<serde_json::Value>::new()));
+
+    let events_clone = received_events.clone();
+    let archives_clone = received_archives.clone();
+
+    // Build the mock router
+    let app = Router::new()
+        .route("/api/event", post(move |Json(payload): Json<serde_json::Value>| {
+            events_clone.lock().unwrap().push(payload);
+            async { Json(serde_json::json!({ "status": "ok", "seq": 42 })) }
+        }))
+        .route("/v1/memories/search", post(|Json(_payload): Json<serde_json::Value>| async {
+            Json(serde_json::json!({
+                "count": 1,
+                "results": [
+                    {
+                        "id": "mem-1",
+                        "path": "test/path",
+                        "snippet": "prior context snippet"
+                    }
+                ]
+            }))
+        }))
+        .route("/v1/memories", post(move |Json(payload): Json<serde_json::Value>| {
+            archives_clone.lock().unwrap().push(payload);
+            async { Json(serde_json::json!({ "status": "ok", "id": "archived-1" })) }
+        }));
+
+    // Start mock server on a random port
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let local_addr = listener.local_addr().unwrap();
+    let mock_server_url = format!("http://{}", local_addr);
+
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    // Configure env variables to point to mock server
+    std::env::set_var("XAVIER_URL", &mock_server_url);
+    std::env::set_var("XAVIER_TOKEN", "mock-token");
+    std::env::set_var("GESTALT_PROJECT", "test-project");
+
+    // Initialize AgentWrapper
+    let vfs = Arc::new(InMemoryVfs::new());
+    let run_id = "run-trace-123".to_string();
+    let agent_id = "test-agent".to_string();
+
+    // We run the printenv command to print XAVIER_CONTEXT
+    let command = "printenv XAVIER_CONTEXT".to_string();
+
+    let wrapper = AgentWrapper::new(vfs, agent_id, run_id, command);
+
+    // Run execution with tracing
+    let result = wrapper.execute_with_trace("fix bug in lib", Some("test-project"), Some(5)).await;
+    assert!(result.is_ok(), "execute_with_trace failed: {:?}", result.err());
+
+    let (_edits, status, stdout, _stderr) = result.unwrap();
+    assert!(status.success());
+    assert!(stdout.contains("prior context snippet"), "Expected injected XAVIER_CONTEXT in stdout, but got: {}", stdout);
+
+    // Give a split second for any background tokio spawns to complete
+    tokio::time::sleep(Duration::from_millis(150)).await;
+
+    // Verify StateDb events
+    let db_path = temp_home.join(".gestalt").join("state.db");
+    let db = StateDb::open(&db_path).unwrap();
+    let events_in_db = db.recent_timeline(10).unwrap();
+    assert!(!events_in_db.is_empty(), "Events should be persisted in StateDb");
+
+    // Check if run_started and run_finished events were logged
+    let start_logged = events_in_db.iter().any(|e| e.payload.contains("run_started"));
+    let finish_logged = events_in_db.iter().any(|e| e.payload.contains("run_finished"));
+    assert!(start_logged, "run_started not found in StateDb");
+    assert!(finish_logged, "run_finished not found in StateDb");
+
+    // Verify archives received
+    let archives = received_archives.lock().unwrap();
+    assert!(!archives.is_empty(), "Mock server should receive run archive");
+    let has_run_result = archives.iter().any(|arch| {
+        arch.get("kind").and_then(|k| k.as_str()) == Some("run_result")
+    });
+    assert!(has_run_result, "Mock server did not receive run_result archive");
+
+    // Clean up environment and files
+    if let Some(h) = old_home {
+        std::env::set_var("HOME", h);
+    } else {
+        std::env::remove_var("HOME");
+    }
+    std::env::remove_var("XAVIER_URL");
+    std::env::remove_var("XAVIER_TOKEN");
+    std::env::remove_var("GESTALT_PROJECT");
+    let _ = std::fs::remove_dir_all(&temp_home);
+}


### PR DESCRIPTION
Implement the thin agent launcher subcommand `gestalt agent exec` matching standard PRE -> RUN -> POST lifecycle and universal bus traceability contract.

Fixes #537

---
*PR created automatically by Jules for task [13102770838533635461](https://jules.google.com/task/13102770838533635461) started by @iberi22*