### PR TITLE
feat-event-log — WS unified adapter (EventStream, HTTP+WS parity)

### DIFF
--- a/gestalt-router/src/ws.rs
+++ b/gestalt-router/src/ws.rs
@@ -4,10 +4,14 @@
 //! [`gestalt_ws::WsServer`], forwarding timeline events to all
 //! connected WebSocket clients.
 
+pub use gestalt_ws;
+
 use gestalt_state::memstate::MemState;
 use gestalt_state::TimelineEvent;
 use gestalt_ws::WsEvent;
 use gestalt_ws::WsServer;
+use std::sync::Arc;
+
 /// Bridges Router state changes to a WebSocket server.
 ///
 /// Subscribes to [`MemState`] state-change broadcasts and forwards
@@ -23,7 +27,9 @@ pub struct WsRouterBridge {
 impl WsRouterBridge {
     /// Create a new bridge wrapping a `WsServer`.
     pub fn new(ws_server: WsServer) -> Self {
-        Self { ws_server }
+        let bridge = Self { ws_server };
+        gestalt_ws::register_adapter(Arc::new(bridge.clone()));
+        bridge
     }
 
     /// Get a reference to the inner WsServer.
@@ -143,6 +149,40 @@ impl WsRouterBridge {
 
         let redacted_event = crate::xavier_sink::redact_ws_event(ws_event);
         ws_server.broadcast(&redacted_event).await;
+    }
+}
+
+impl gestalt_ws::EventStream for WsRouterBridge {
+    fn publish(&self, ev: &gestalt_ws::BusEvent) {
+        self.ws_server.broadcast_bus(ev);
+    }
+
+    fn subscribe(&self, filter: Option<String>) -> gestalt_ws::BoxStream<'static, gestalt_ws::BusEvent> {
+        use gestalt_ws::StreamExt;
+        let rx = self.ws_server.broadcast_bus_tx.subscribe();
+
+        let s = gestalt_ws::futures_util::stream::unfold(rx, |mut rx| async move {
+            loop {
+                match rx.recv().await {
+                    Ok(ev) => return Some((ev, rx)),
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+                }
+            }
+        });
+
+        if let Some(f) = filter {
+            s.filter(move |ev| {
+                let f_clone = f.clone();
+                let ev_type = ev.event_type.clone();
+                let ev_agent = ev.agent.clone();
+                async move {
+                    ev_type == f_clone || ev_agent == f_clone
+                }
+            }).boxed()
+        } else {
+            s.boxed()
+        }
     }
 }
 

--- a/gestalt-router/tests/integration_test.rs
+++ b/gestalt-router/tests/integration_test.rs
@@ -62,6 +62,7 @@ fn test_full_pipeline_agent_spec_construction() {
             map.insert("PATH".to_string(), "/usr/bin".to_string());
             map
         }),
+        capabilities: vec![],
     };
     assert_eq!(agent.id, "test-agent");
     assert_eq!(agent.command, "echo");
@@ -75,6 +76,7 @@ fn test_run_spec_construction() {
         args: vec!["hello".to_string()],
         allowed_paths: None,
         env: None,
+        capabilities: vec![],
     };
     let spec = RunSpec {
         base_ref: "main".to_string(),
@@ -100,6 +102,7 @@ fn test_multi_agent_specs() {
             args: vec![format!("hello {}", i)],
             allowed_paths: None,
             env: None,
+            capabilities: vec![],
         })
         .collect();
     assert_eq!(agents.len(), 3);

--- a/gestalt-router/tests/router_tests.rs
+++ b/gestalt-router/tests/router_tests.rs
@@ -96,6 +96,7 @@ fn test_agent_spec_serialization_roundtrip() {
             ("PATH".into(), "/usr/bin".into()),
             ("HOME".into(), "/home/user".into()),
         ])),
+        capabilities: vec![],
     };
 
     let json = serde_json::to_string(&spec).unwrap();
@@ -124,6 +125,7 @@ fn test_agent_spec_optional_fields_roundtrip() {
         args: vec![],
         allowed_paths: None,
         env: None,
+        capabilities: vec![],
     };
 
     let json = serde_json::to_string(&spec).unwrap();
@@ -143,6 +145,7 @@ fn test_run_spec_with_all_fields() {
             args: vec!["hi".into()],
             allowed_paths: None,
             env: None,
+            capabilities: vec![],
         },
         AgentSpec {
             id: "a2".into(),
@@ -150,6 +153,7 @@ fn test_run_spec_with_all_fields() {
             args: vec!["/dev/null".into()],
             allowed_paths: None,
             env: None,
+            capabilities: vec![],
         },
     ];
 

--- a/gestalt-ws/src/lib.rs
+++ b/gestalt-ws/src/lib.rs
@@ -24,8 +24,476 @@
 //! | `"lock_acquired"`      | `LockAcquired`        |
 //! | `"lock_released"`      | `LockReleased`        |
 
-pub mod event;
-pub mod server;
+use std::net::SocketAddr;
+use std::sync::Arc;
+pub use futures_util::{SinkExt, StreamExt};
+pub use futures_util::stream::BoxStream;
+pub use futures_util;
+use tokio::net::TcpListener;
+use tokio::sync::broadcast;
+use tokio::task::JoinHandle;
+use tokio_tungstenite::accept_async;
+use tokio_tungstenite::tungstenite::Message;
+use tracing::{debug, error, info, warn};
+use serde::{Deserialize, Serialize};
 
-pub use event::WsEvent;
-pub use server::WsServer;
+/// Current protocol schema version for WebSocket events.
+pub const CURRENT_VERSION: u32 = 1;
+
+fn default_version() -> u32 {
+    CURRENT_VERSION
+}
+
+/// Envelope wrapping standard WebSocket events with schema versioning.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct WsEnvelope {
+    /// The protocol schema version of the event.
+    #[serde(default = "default_version")]
+    pub version: u32,
+    /// The flattened WebSocket event.
+    #[serde(flatten)]
+    pub event: WsEvent,
+}
+
+/// Events that can be broadcast to WebSocket clients.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(tag = "type", content = "data", rename_all = "snake_case")]
+pub enum WsEvent {
+    /// An agent's state has changed.
+    StateChanged {
+        run_id: String,
+        agent_id: String,
+        state: String,
+    },
+    /// A file lock was acquired by an agent.
+    LockAcquired {
+        run_id: String,
+        agent_id: String,
+        path: String,
+    },
+    /// A file lock was released by an agent.
+    LockReleased {
+        run_id: String,
+        agent_id: String,
+        path: String,
+    },
+    /// A run has started.
+    RunStarted {
+        run_id: String,
+        task: String,
+        agents: Vec<String>,
+    },
+    /// A run has finished.
+    RunFinished { run_id: String, summary: String },
+    /// A real-time lock conflict was detected between two agents.
+    ConflictDetected {
+        run_id: String,
+        agent_a: String,
+        agent_b: String,
+        path: String,
+        message: String,
+    },
+}
+
+impl WsEvent {
+    /// Serialize this event to a JSON string for WebSocket broadcast.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string(self)
+    }
+}
+
+/// A structured event pushed onto the universal information bus.
+///
+/// Carries full traceability metadata: who sent it (`agent`), what happened
+/// (`event_type`, `state`), which run/project it belongs to, and free-form
+/// `metadata` for LLM/provider/decision context.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct BusEvent {
+    /// Originating agent: "hermes" | "jules" | "agent-cli" | "gestalt" | ...
+    pub agent: String,
+    /// Event kind: "run_started" | "agent_state" | "checkpoint" | "decision" | ...
+    pub event_type: String,
+    /// Run identifier, when the event belongs to a Gestalt orchestration run.
+    #[serde(default)]
+    pub run_id: Option<String>,
+    /// Project name (e.g. "gestalt", "xavier", "nido").
+    #[serde(default)]
+    pub project: Option<String>,
+    /// Agent state: Pending | Running | Success | Timeout | Crashed | NoChanges.
+    #[serde(default)]
+    pub state: Option<String>,
+    /// Human-readable one-line summary of what happened.
+    pub summary: String,
+    /// Free-form traceability metadata: {"llm": "...", "provider": "...",
+    /// "decision": "...", "requested_by": "...", "tool_calls": N, ...}.
+    #[serde(default)]
+    pub metadata: serde_json::Value,
+    /// RFC3339 timestamp of the event.
+    #[serde(default)]
+    pub ts: String,
+}
+
+/// Decoupled EventStream trait to support unified adapter behaviors.
+pub trait EventStream {
+    /// Publish a BusEvent onto the WebSocket stream.
+    fn publish(&self, ev: &BusEvent);
+    /// Subscribe to the WebSocket stream, optionally filtered by event_type or agent.
+    fn subscribe(&self, filter: Option<String>) -> BoxStream<'static, BusEvent>;
+}
+
+static ACTIVE_ADAPTERS: std::sync::OnceLock<std::sync::RwLock<Vec<Arc<dyn EventStream + Send + Sync>>>> = std::sync::OnceLock::new();
+
+/// Register an active WebSocket adapter instance.
+pub fn register_adapter(adapter: Arc<dyn EventStream + Send + Sync>) {
+    let adapters = ACTIVE_ADAPTERS.get_or_init(|| std::sync::RwLock::new(Vec::new()));
+    if let Ok(mut lock) = adapters.write() {
+        lock.push(adapter);
+    }
+}
+
+/// Publish an event to all registered WebSocket adapters.
+pub fn publish_to_all_adapters(ev: &BusEvent) {
+    if let Some(adapters) = ACTIVE_ADAPTERS.get() {
+        if let Ok(lock) = adapters.read() {
+            for adapter in lock.iter() {
+                adapter.publish(ev);
+            }
+        }
+    }
+}
+
+/// A lightweight WebSocket server that broadcasts timeline events
+/// to all connected clients.
+///
+/// The server listens on a configured address, accepts WebSocket
+/// connections, and fans out every [`broadcast`](Self::broadcast) call
+/// to every connected client as a JSON text frame.
+#[derive(Clone)]
+pub struct WsServer {
+    /// Broadcast sender — cloned for each connected client on subscribe.
+    pub broadcast_tx: broadcast::Sender<String>,
+    /// Dedicated broadcast channel for BusEvents (stream subscribe).
+    pub broadcast_bus_tx: broadcast::Sender<BusEvent>,
+    /// Handle to the TCP accept loop (dropped on shutdown).
+    #[allow(dead_code)]
+    accept_handle: Arc<tokio::sync::Mutex<Option<JoinHandle<()>>>>,
+}
+
+impl WsServer {
+    /// Create a new `WsServer` without binding to a port.
+    ///
+    /// Returns the server instance and a receiver for the broadcast
+    /// channel (useful for testing).
+    pub fn new() -> (Self, broadcast::Receiver<String>) {
+        let (tx, rx) = broadcast::channel(1024);
+        let (bus_tx, _) = broadcast::channel(1024);
+        let server = Self {
+            broadcast_tx: tx,
+            broadcast_bus_tx: bus_tx,
+            accept_handle: Arc::new(tokio::sync::Mutex::new(None)),
+        };
+        (server, rx)
+    }
+
+    /// Start the WebSocket server on `addr`.
+    ///
+    /// Spawns a background task that accepts incoming TCP connections
+    /// and upgrades them to WebSocket. Each connected client receives
+    /// all future [`broadcast`](Self::broadcast) events.
+    pub async fn bind(addr: SocketAddr) -> Self {
+        let (tx, _) = broadcast::channel(1024);
+        let (bus_tx, _) = broadcast::channel(1024);
+        let listener = TcpListener::bind(addr).await.unwrap_or_else(|e| {
+            panic!("Failed to bind WsServer to {addr}: {e}");
+        });
+
+        info!("WebSocket server listening on {addr}");
+
+        let tx_clone = tx.clone();
+        let handle = tokio::spawn(async move {
+            Self::accept_loop(listener, tx_clone).await;
+        });
+
+        Self {
+            broadcast_tx: tx,
+            broadcast_bus_tx: bus_tx,
+            accept_handle: Arc::new(tokio::sync::Mutex::new(Some(handle))),
+        }
+    }
+
+    /// Broadcast a `WsEvent` to all connected WebSocket clients.
+    ///
+    /// The event is wrapped in a `WsEnvelope` with the current schema version,
+    /// serialised to JSON, and sent to every client.
+    /// If a client has disconnected, its receiver is silently dropped.
+    /// This is fire-and-forget — errors are logged but not returned.
+    pub async fn broadcast(&self, event: &WsEvent) {
+        let envelope = WsEnvelope {
+            version: CURRENT_VERSION,
+            event: event.clone(),
+        };
+
+        match serde_json::to_string(&envelope) {
+            Ok(json) => {
+                let count = self.broadcast_tx.send(json);
+                match count {
+                    Ok(n) => {
+                        debug!("Broadcast WsEvent (wrapped in WsEnvelope) to {n} subscribers");
+                    },
+                    Err(_) => {
+                        // No receivers — normal when no clients are connected
+                        debug!("WsEnvelope broadcast: no receivers");
+                    },
+                }
+            },
+            Err(e) => {
+                error!("Failed to serialise WsEnvelope for broadcast: {e}");
+            },
+        }
+    }
+
+    /// Broadcast a canonical `BusEvent` to all connected WebSocket clients.
+    ///
+    /// The event is serialised to raw JSON (without WsEnvelope wrapping, to maintain parity with HTTP),
+    /// and sent to every client. It is also dispatched to subscribers of the EventStream.
+    pub fn broadcast_bus(&self, event: &BusEvent) {
+        if let Ok(json) = serde_json::to_string(event) {
+            let _ = self.broadcast_tx.send(json);
+        }
+        let _ = self.broadcast_bus_tx.send(event.clone());
+    }
+
+    /// Get the number of currently connected clients.
+    pub fn connected_clients(&self) -> usize {
+        self.broadcast_tx.receiver_count()
+    }
+
+    /// Accept loop — runs forever accepting connections.
+    async fn accept_loop(listener: TcpListener, tx: broadcast::Sender<String>) {
+        loop {
+            match listener.accept().await {
+                Ok((stream, peer_addr)) => {
+                    debug!("New WebSocket connection from {peer_addr}");
+                    let peer_rx = tx.subscribe();
+                    tokio::spawn(async move {
+                        Self::handle_connection(stream, peer_addr, peer_rx).await;
+                    });
+                },
+                Err(e) => {
+                    error!("Failed to accept connection: {e}");
+                    // Brief pause to avoid busy-loop on persistent errors
+                    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+                },
+            }
+        }
+    }
+
+    /// Handle a single WebSocket connection.
+    ///
+    /// Upgrades the TCP stream to WebSocket, then forwards every
+    /// broadcast event to the client until the client disconnects.
+    async fn handle_connection(
+        stream: tokio::net::TcpStream,
+        peer_addr: SocketAddr,
+        mut rx: broadcast::Receiver<String>,
+    ) {
+        let ws_stream = match accept_async(stream).await {
+            Ok(ws) => ws,
+            Err(e) => {
+                warn!("WebSocket handshake failed for {peer_addr}: {e}");
+                return;
+            },
+        };
+
+        let (mut write, mut read) = ws_stream.split();
+
+        loop {
+            tokio::select! {
+                msg = rx.recv() => {
+                    match msg {
+                        Ok(json) => {
+                            if let Err(e) = write.send(Message::Text(json)).await {
+                                debug!("WebSocket send failed for {peer_addr}: {e}");
+                                break;
+                            }
+                        }
+                        Err(broadcast::error::RecvError::Lagged(n)) => {
+                            warn!("WebSocket client {peer_addr} lagged by {n} messages");
+                        }
+                        Err(broadcast::error::RecvError::Closed) => {
+                            debug!("WebSocket broadcast channel closed for {peer_addr}");
+                            break;
+                        }
+                    }
+                }
+                msg = read.next() => {
+                    match msg {
+                        Some(Ok(Message::Close(_))) | None => {
+                            debug!("WebSocket client {peer_addr} disconnected");
+                            break;
+                        }
+                        Some(Ok(Message::Ping(data))) => {
+                            let _ = write.send(Message::Pong(data)).await;
+                        }
+                        _ => {}
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ws_event_serialization_roundtrip() {
+        let events = vec![
+            WsEvent::StateChanged {
+                run_id: "run-1".into(),
+                agent_id: "agent-1".into(),
+                state: "running".into(),
+            },
+            WsEvent::LockAcquired {
+                run_id: "run-1".into(),
+                agent_id: "agent-1".into(),
+                path: "/tmp/test.lock".into(),
+            },
+            WsEvent::LockReleased {
+                run_id: "run-1".into(),
+                agent_id: "agent-1".into(),
+                path: "/tmp/test.lock".into(),
+            },
+            WsEvent::RunStarted {
+                run_id: "run-1".into(),
+                task: "test task".into(),
+                agents: vec!["agent-1".into(), "agent-2".into()],
+            },
+            WsEvent::RunFinished {
+                run_id: "run-1".into(),
+                summary: "completed with 2 agents".into(),
+            },
+            WsEvent::ConflictDetected {
+                run_id: "run-1".into(),
+                agent_a: "agent-1".into(),
+                agent_b: "agent-2".into(),
+                path: "src/file.rs".into(),
+                message: "Conflict: agents agent-1 and agent-2 both locked src/file.rs".into(),
+            },
+        ];
+
+        for event in &events {
+            let json = event.to_json().unwrap();
+            let deser: WsEvent = serde_json::from_str(&json).unwrap();
+            assert_eq!(*event, deser, "roundtrip failed for event: {:?}", event);
+        }
+    }
+
+    #[test]
+    fn test_ws_event_json_format_tagged() {
+        let event = WsEvent::StateChanged {
+            run_id: "r1".into(),
+            agent_id: "a1".into(),
+            state: "running".into(),
+        };
+        let json = event.to_json().unwrap();
+        assert!(json.contains("\"run_id\""));
+        assert!(json.contains("\"agent_id\""));
+        assert!(json.contains("\"state\""));
+    }
+
+    #[test]
+    fn test_ws_envelope_roundtrip() {
+        let event = WsEvent::StateChanged {
+            run_id: "r1".into(),
+            agent_id: "a1".into(),
+            state: "running".into(),
+        };
+        let envelope = WsEnvelope {
+            version: CURRENT_VERSION,
+            event: event.clone(),
+        };
+
+        let json = serde_json::to_string(&envelope).unwrap();
+        // Check that version field is present at root level
+        assert!(json.contains("\"version\":1"));
+        assert!(json.contains("\"type\":\"state_changed\""));
+
+        let deser: WsEnvelope = serde_json::from_str(&json).unwrap();
+        assert_eq!(deser.version, CURRENT_VERSION);
+        assert_eq!(deser.event, event);
+    }
+
+    #[test]
+    fn test_ws_envelope_backward_compatibility() {
+        // Without version field, should default to CURRENT_VERSION
+        let raw_json =
+            r#"{"type":"state_changed","data":{"run_id":"r1","agent_id":"a1","state":"running"}}"#;
+        let deser: WsEnvelope = serde_json::from_str(raw_json).unwrap();
+        assert_eq!(deser.version, CURRENT_VERSION);
+        if let WsEvent::StateChanged {
+            run_id,
+            agent_id,
+            state,
+        } = deser.event
+        {
+            assert_eq!(run_id, "r1");
+            assert_eq!(agent_id, "a1");
+            assert_eq!(state, "running");
+        } else {
+            panic!("Expected StateChanged variant");
+        }
+    }
+
+    #[tokio::test]
+    async fn test_ws_server_new_broadcasts() {
+        let (server, mut rx) = WsServer::new();
+
+        let event = WsEvent::StateChanged {
+            run_id: "test-run".into(),
+            agent_id: "agent-1".into(),
+            state: "running".into(),
+        };
+
+        server.broadcast(&event).await;
+
+        let received: String = rx.recv().await.unwrap();
+        let deser: WsEnvelope = serde_json::from_str(&received).unwrap();
+        assert_eq!(deser.event, event);
+        assert_eq!(deser.version, CURRENT_VERSION);
+    }
+
+    #[tokio::test]
+    async fn test_ws_server_connected_clients() {
+        let (server, _rx) = WsServer::new();
+        // _rx from new() counts as one subscriber
+        assert_eq!(server.connected_clients(), 1);
+
+        let _rx2 = server.broadcast_tx.subscribe();
+        assert_eq!(server.connected_clients(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_ws_server_multiple_subscribers() {
+        let (server, _rx1) = WsServer::new();
+        let mut rx2 = server.broadcast_tx.subscribe();
+        let mut rx3 = server.broadcast_tx.subscribe();
+
+        let event = WsEvent::RunStarted {
+            run_id: "multi-test".into(),
+            task: "multi-subscriber task".into(),
+            agents: vec!["agent-a".into()],
+        };
+
+        server.broadcast(&event).await;
+
+        // Both subscribers should receive the event
+        let received2: String = rx2.recv().await.unwrap();
+        let received3: String = rx3.recv().await.unwrap();
+        let deser2: WsEnvelope = serde_json::from_str(&received2).unwrap();
+        let deser3: WsEnvelope = serde_json::from_str(&received3).unwrap();
+        assert_eq!(deser2.event, event);
+        assert_eq!(deser3.event, event);
+    }
+}

--- a/gestalt-ws/tests/integration_tests.rs
+++ b/gestalt-ws/tests/integration_tests.rs
@@ -1,0 +1,152 @@
+//! Integration tests for gestalt-ws.
+//!
+//! Verifies WebSocket publishing, subscription, and filtering under the unified EventStream interface.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+use futures_util::StreamExt;
+use tokio_tungstenite::connect_async;
+use tokio_tungstenite::tungstenite::Message;
+use gestalt_ws::{BusEvent, EventStream, WsServer, publish_to_all_adapters};
+
+/// Find a free ephemeral TCP port on localhost for test isolation.
+fn free_addr() -> SocketAddr {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+}
+
+/// Helper to connect a WebSocket client to the local test server.
+async fn connect_ws(addr: SocketAddr) -> impl StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin {
+    let (ws, _) = connect_async(format!("ws://{addr}")).await.unwrap();
+    ws
+}
+
+/// Helper to read a Text message with a timeout.
+async fn recv_text(
+    ws: &mut (impl StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin),
+) -> String {
+    match tokio::time::timeout(Duration::from_secs(5), ws.next()).await {
+        Ok(Some(Ok(Message::Text(text)))) => text,
+        Ok(Some(Ok(other))) => panic!("Expected Text frame, got: {other:?}"),
+        Ok(Some(Err(e))) => panic!("WebSocket error: {e}"),
+        Ok(None) => panic!("WebSocket stream ended unexpectedly"),
+        Err(_) => panic!("Timeout (5s) waiting for WebSocket message"),
+    }
+}
+
+/// Mock EventStream implementation for testing registration/publishing.
+#[derive(Clone)]
+struct MockEventStream {
+    server: WsServer,
+}
+
+impl EventStream for MockEventStream {
+    fn publish(&self, ev: &BusEvent) {
+        self.server.broadcast_bus(ev);
+    }
+
+    fn subscribe(&self, filter: Option<String>) -> gestalt_ws::BoxStream<'static, BusEvent> {
+        let rx = self.server.broadcast_bus_tx.subscribe();
+        let s = futures_util::stream::unfold(rx, |mut rx| async move {
+            loop {
+                match rx.recv().await {
+                    Ok(ev) => return Some((ev, rx)),
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
+                }
+            }
+        });
+
+        if let Some(f) = filter {
+            s.filter(move |ev| {
+                let f_clone = f.clone();
+                let ev_type = ev.event_type.clone();
+                let ev_agent = ev.agent.clone();
+                async move {
+                    ev_type == f_clone || ev_agent == f_clone
+                }
+            }).boxed()
+        } else {
+            s.boxed()
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_ws_publish_receive_bus_event() {
+    let addr = free_addr();
+    let server = WsServer::bind(addr).await;
+    let mut client = connect_ws(addr).await;
+
+    // Register our mock event stream (which wraps WsServer) in ACTIVE_ADAPTERS
+    let adapter = std::sync::Arc::new(MockEventStream { server: server.clone() });
+    gestalt_ws::register_adapter(adapter);
+
+    let event = BusEvent {
+        agent: "test-agent".to_string(),
+        event_type: "run_started".to_string(),
+        run_id: Some("run-abc".to_string()),
+        project: Some("gestalt".to_string()),
+        state: Some("Running".to_string()),
+        summary: "Pipeline started".to_string(),
+        metadata: serde_json::json!({"triggered_by": "test"}),
+        ts: "2026-08-05T12:00:00Z".to_string(),
+    };
+
+    // Publish using the decoupled global registry
+    publish_to_all_adapters(&event);
+
+    let text = recv_text(&mut client).await;
+    let received: BusEvent = serde_json::from_str(&text).unwrap();
+
+    assert_eq!(received.agent, "test-agent");
+    assert_eq!(received.event_type, "run_started");
+    assert_eq!(received.run_id, Some("run-abc".to_string()));
+    assert_eq!(received.summary, "Pipeline started");
+}
+
+#[tokio::test]
+async fn test_event_stream_subscribe_filtering() {
+    let (server, _rx) = WsServer::new();
+    let adapter = MockEventStream { server };
+
+    // Subscribe to only "checkpoint" events
+    let mut stream = adapter.subscribe(Some("checkpoint".to_string()));
+
+    let event1 = BusEvent {
+        agent: "jules".to_string(),
+        event_type: "run_started".to_string(),
+        run_id: None,
+        project: None,
+        state: None,
+        summary: "Ignored".to_string(),
+        metadata: serde_json::Value::Null,
+        ts: String::new(),
+    };
+
+    let event2 = BusEvent {
+        agent: "jules".to_string(),
+        event_type: "checkpoint".to_string(),
+        run_id: None,
+        project: None,
+        state: None,
+        summary: "Matched".to_string(),
+        metadata: serde_json::Value::Null,
+        ts: String::new(),
+    };
+
+    // Publish both events
+    adapter.publish(&event1);
+    adapter.publish(&event2);
+
+    // The stream should receive the matching one first
+    let received = tokio::time::timeout(Duration::from_secs(2), stream.next())
+        .await
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(received.event_type, "checkpoint");
+    assert_eq!(received.summary, "Matched");
+}

--- a/gestalt_cli/src/bus.rs
+++ b/gestalt_cli/src/bus.rs
@@ -49,6 +49,19 @@ async fn handle_event_http(
         .await
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e))?;
 
+    // WS publish hook: publish the BusEvent to the WS stream
+    let ev_ws = gestalt_router::ws::gestalt_ws::BusEvent {
+        agent: ev.agent.clone(),
+        event_type: ev.event_type.clone(),
+        run_id: ev.run_id.clone(),
+        project: ev.project.clone(),
+        state: ev.state.clone(),
+        summary: ev.summary.clone(),
+        metadata: ev.metadata.clone(),
+        ts: ev.ts.clone(),
+    };
+    gestalt_router::ws::gestalt_ws::publish_to_all_adapters(&ev_ws);
+
     match result {
         Some(seq) => Ok(Json(serde_json::json!({
             "status": "ok",


### PR DESCRIPTION
This PR implements the Part A WS unified adapter (one event model, HTTP+WS parity). It introduces the decoupled `EventStream` trait and `BusEvent` schema inside the `gestalt-ws` library crate, implements `EventStream` for the WebSocket adapter `WsRouterBridge` (broadcasting raw JSON payloads to clients to mirror HTTP and support stream subscription/filtering), registers the bridge to a global adapter registry, and links the HTTP event bus handler in `gestalt_cli/src/bus.rs` to stream incoming events onto WebSocket. It also delivers robust new integration tests in `gestalt-ws/tests/` and fixes E0063 compilation issues in the test suites.

Fixes #542

---
*PR created automatically by Jules for task [8156146645414400974](https://jules.google.com/task/8156146645414400974) started by @iberi22*