### PR TITLE
feat-event-bus — FEAT-GT-019 — Bus query API: GET /api/events filters (agent/type/project/after_seq) + cursor pagination

### DIFF
--- a/gestalt-router/src/ws.rs
+++ b/gestalt-router/src/ws.rs
@@ -162,6 +162,7 @@ mod tests {
             payload: r#"{"state":"running"}"#.into(),
             created_at: chrono::Utc::now(),
             dedup_hash: None,
+            project: None,
         };
 
         WsRouterBridge::forward_timeline_event(&server, &event).await;
@@ -189,6 +190,7 @@ mod tests {
             payload: r#"{"path":"/tmp/test.lock"}"#.into(),
             created_at: chrono::Utc::now(),
             dedup_hash: None,
+            project: None,
         };
 
         WsRouterBridge::forward_timeline_event(&server, &event).await;
@@ -216,6 +218,7 @@ mod tests {
             payload: "{}".into(),
             created_at: chrono::Utc::now(),
             dedup_hash: None,
+            project: None,
         };
 
         // This should not panic or broadcast anything

--- a/gestalt-state/src/memstate.rs
+++ b/gestalt-state/src/memstate.rs
@@ -116,6 +116,7 @@ impl MemState {
             payload: serde_json::json!({ "state": state }).to_string(),
             created_at: chrono::Utc::now(),
             dedup_hash: None,
+            project: None,
         };
 
         let _ = self.event_tx.send(event);
@@ -222,6 +223,7 @@ impl MemState {
                     payload,
                     created_at: chrono::Utc::now(),
                     dedup_hash: None,
+                    project: None,
                 });
             }
         }
@@ -291,6 +293,7 @@ impl MemState {
             payload: payload.to_string(),
             created_at: chrono::Utc::now(),
             dedup_hash: None,
+            project: None,
         };
 
         let subscriber_count = self.event_tx.receiver_count();

--- a/gestalt-state/src/schema.rs
+++ b/gestalt-state/src/schema.rs
@@ -98,6 +98,8 @@ pub struct TimelineEvent {
     pub created_at: DateTime<Utc>,
     #[serde(default)]
     pub dedup_hash: Option<String>,
+    #[serde(default)]
+    pub project: Option<String>,
 }
 
 // Migration pattern elements required for static analysis validation:

--- a/gestalt-state/src/statedb.rs
+++ b/gestalt-state/src/statedb.rs
@@ -229,6 +229,32 @@ impl StateDb {
         )
         .context("Failed to create idx_timeline_dedup index")?;
 
+        // Additive migration: check if project column exists in timeline table
+        let has_project_column = {
+            let mut stmt = conn.prepare("PRAGMA table_info(timeline)")?;
+            let mut rows = stmt.query([])?;
+            let mut found = false;
+            while let Some(row) = rows.next()? {
+                let name: String = row.get(1)?;
+                if name == "project" {
+                    found = true;
+                    break;
+                }
+            }
+            found
+        };
+
+        if !has_project_column {
+            conn.execute("ALTER TABLE timeline ADD COLUMN project TEXT", [])
+                .context("Failed to add project column")?;
+        }
+
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_timeline_project ON timeline(project)",
+            [],
+        )
+        .context("Failed to create idx_timeline_project index")?;
+
         Ok(())
     }
 
@@ -477,13 +503,17 @@ impl StateDb {
         payload: &str,
         dedup_hash: Option<&str>,
     ) -> Result<TimelineEvent> {
+        let project = serde_json::from_str::<serde_json::Value>(payload)
+            .ok()
+            .and_then(|v| v.get("project").and_then(|p| p.as_str().map(|s| s.to_string())));
+
         self.execute_transaction(|tx| {
             let now = Utc::now().to_rfc3339();
 
             tx.execute(
-                "INSERT INTO timeline (run_id, agent_id, event_type, payload, created_at, dedup_hash)
-                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
-                rusqlite::params![run_id, agent_id, event_type, payload, now, dedup_hash],
+                "INSERT INTO timeline (run_id, agent_id, event_type, payload, created_at, dedup_hash, project)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)",
+                rusqlite::params![run_id, agent_id, event_type, payload, now, dedup_hash, project],
             )
             .context("Failed to insert timeline event")?;
 
@@ -497,6 +527,7 @@ impl StateDb {
                 payload: payload.to_string(),
                 created_at: now.parse::<DateTime<Utc>>().unwrap_or_else(|_| Utc::now()),
                 dedup_hash: dedup_hash.map(|s| s.to_string()),
+                project: project.clone(),
             })
         })
     }
@@ -518,7 +549,7 @@ impl StateDb {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn
             .prepare(
-                "SELECT seq, run_id, agent_id, event_type, payload, created_at, dedup_hash
+                "SELECT seq, run_id, agent_id, event_type, payload, created_at, dedup_hash, project
                  FROM timeline WHERE created_at < ?1
                  ORDER BY created_at ASC",
             )
@@ -539,6 +570,7 @@ impl StateDb {
                         .parse::<DateTime<Utc>>()
                         .unwrap_or_else(|_| Utc::now()),
                     dedup_hash: row.get(6)?,
+                    project: row.get(7)?,
                 })
             })
             .context("Failed to query timeline")?
@@ -567,7 +599,7 @@ impl StateDb {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn
             .prepare(
-                "SELECT seq, run_id, agent_id, event_type, payload, created_at, dedup_hash
+                "SELECT seq, run_id, agent_id, event_type, payload, created_at, dedup_hash, project
                  FROM timeline WHERE run_id = ?1
                  ORDER BY seq ASC LIMIT ?2",
             )
@@ -587,6 +619,7 @@ impl StateDb {
                         .parse::<DateTime<Utc>>()
                         .unwrap_or_else(|_| Utc::now()),
                     dedup_hash: row.get(6)?,
+                    project: row.get(7)?,
                 })
             })
             .context("Failed to query timeline")?
@@ -602,7 +635,7 @@ impl StateDb {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn
             .prepare(
-                "SELECT seq, run_id, agent_id, event_type, payload, created_at, dedup_hash
+                "SELECT seq, run_id, agent_id, event_type, payload, created_at, dedup_hash, project
                  FROM timeline
                  ORDER BY seq DESC LIMIT ?1",
             )
@@ -622,6 +655,7 @@ impl StateDb {
                         .parse::<DateTime<Utc>>()
                         .unwrap_or_else(|_| Utc::now()),
                     dedup_hash: row.get(6)?,
+                    project: row.get(7)?,
                 })
             })
             .context("Failed to query recent timeline")?
@@ -636,7 +670,7 @@ impl StateDb {
         let conn = self.conn.lock().unwrap();
         let mut stmt = conn
             .prepare(
-                "SELECT seq, run_id, agent_id, event_type, payload, created_at, dedup_hash
+                "SELECT seq, run_id, agent_id, event_type, payload, created_at, dedup_hash, project
                  FROM timeline WHERE run_id = ?1
                  ORDER BY seq ASC",
             )
@@ -656,11 +690,84 @@ impl StateDb {
                         .parse::<DateTime<Utc>>()
                         .unwrap_or_else(|_| Utc::now()),
                     dedup_hash: row.get(6)?,
+                    project: row.get(7)?,
                 })
             })
             .context("Failed to query timeline by run")?
             .collect::<Result<Vec<_>, _>>()
             .context("Failed to read timeline events by run")?;
+
+        Ok(events)
+    }
+
+    /// Query timeline events with filters and cursor-based pagination.
+    pub fn query_timeline(
+        &self,
+        agent: Option<&str>,
+        event_type: Option<&str>,
+        project: Option<&str>,
+        after_seq: Option<i64>,
+        limit: i64,
+    ) -> Result<Vec<TimelineEvent>> {
+        let conn = self.conn.lock().unwrap();
+        let mut query = "SELECT seq, run_id, agent_id, event_type, payload, created_at, dedup_hash, project FROM timeline WHERE 1=1".to_string();
+
+        let agent_owned = agent.map(|s| s.to_string());
+        let event_type_owned = event_type.map(|s| s.to_string());
+        let project_owned = project.map(|s| s.to_string());
+
+        let mut params: Vec<&dyn rusqlite::ToSql> = Vec::new();
+
+        if let Some(ref a) = agent_owned {
+            query.push_str(" AND agent_id = ?");
+            params.push(a);
+        }
+        if let Some(ref et) = event_type_owned {
+            query.push_str(" AND event_type = ?");
+            params.push(et);
+        }
+        if let Some(ref p) = project_owned {
+            query.push_str(" AND project = ?");
+            params.push(p);
+        }
+        if let Some(ref after) = after_seq {
+            query.push_str(" AND seq > ?");
+            params.push(after);
+        }
+
+        if after_seq.is_some() {
+            query.push_str(" ORDER BY seq ASC LIMIT ?");
+        } else {
+            query.push_str(" ORDER BY seq DESC LIMIT ?");
+        }
+        params.push(&limit);
+
+        let mut stmt = conn.prepare(&query).context("Failed to prepare query_timeline statement")?;
+        let mut events = stmt
+            .query_map(&*params, |row| {
+                let seq: i64 = row.get(0)?;
+                let created_at_str: String = row.get(5)?;
+                Ok(TimelineEvent {
+                    seq: Some(seq),
+                    run_id: row.get(1)?,
+                    agent_id: row.get(2)?,
+                    event_type: row.get(3)?,
+                    payload: row.get(4)?,
+                    created_at: created_at_str
+                        .parse::<DateTime<Utc>>()
+                        .unwrap_or_else(|_| Utc::now()),
+                    dedup_hash: row.get(6)?,
+                    project: row.get(7)?,
+                })
+            })
+            .context("Failed to query timeline events with filters")?
+            .collect::<Result<Vec<_>, _>>()
+            .context("Failed to read timeline events with filters")?;
+
+        // If we fetched the tail (after_seq was None), they are in DESC order; reverse them to chronological order.
+        if after_seq.is_none() {
+            events.reverse();
+        }
 
         Ok(events)
     }
@@ -786,6 +893,64 @@ mod tests {
         // First event should be the oldest (ASC order)
         assert_eq!(timeline[0].event_type, "started");
         assert_eq!(timeline[1].event_type, "completed");
+    }
+
+    #[test]
+    fn test_query_timeline_with_filters() {
+        let db = setup_db();
+
+        db.create_run("run-001", "{}").unwrap();
+
+        // Push events with different fields
+        db.push_event_with_hash("run-001", Some("agent-1"), "event-a", r#"{"project": "proj-1"}"#, None).unwrap();
+        db.push_event_with_hash("run-001", Some("agent-1"), "event-b", r#"{"project": "proj-2"}"#, None).unwrap();
+        db.push_event_with_hash("run-001", Some("agent-2"), "event-a", r#"{"project": "proj-1"}"#, None).unwrap();
+        db.push_event_with_hash("run-001", Some("agent-2"), "event-b", r#"{"project": "proj-2"}"#, None).unwrap();
+
+        // 1. Filter by project
+        let results = db.query_timeline(None, None, Some("proj-1"), None, 10).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].event_type, "event-a");
+        assert_eq!(results[1].event_type, "event-a");
+
+        // 2. Filter by agent
+        let results = db.query_timeline(Some("agent-1"), None, None, None, 10).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].project, Some("proj-1".to_string()));
+        assert_eq!(results[1].project, Some("proj-2".to_string()));
+
+        // 3. Filter by event_type
+        let results = db.query_timeline(None, Some("event-b"), None, None, 10).unwrap();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].project, Some("proj-2".to_string()));
+        assert_eq!(results[1].project, Some("proj-2".to_string()));
+
+        // 4. Cursor pagination (after_seq)
+        // Fetch with limit 2 (descending because after_seq is None)
+        let first_page = db.query_timeline(None, None, None, None, 2).unwrap();
+        assert_eq!(first_page.len(), 2);
+        let last_seq = first_page[1].seq.unwrap();
+
+        // Next page using after_seq (ascending)
+        let second_page = db.query_timeline(None, None, None, Some(last_seq), 2).unwrap();
+        // Since we got the most recent 2 events in first_page (3 and 4), seq > 4 should be empty.
+        // Wait, let's verify exact IDs. The events are:
+        // seq 1: agent-1, event-a, proj-1
+        // seq 2: agent-1, event-b, proj-2
+        // seq 3: agent-2, event-a, proj-1
+        // seq 4: agent-2, event-b, proj-2
+        // If we query with after_seq = None, ORDER BY seq DESC LIMIT 2:
+        // returns seq 4 and 3. Reverser yields seq 3, then 4.
+        // first_page[0] is seq 3, first_page[1] is seq 4.
+        // last_seq is 4.
+        // query with after_seq = 4 -> seq > 4 LIMIT 2 -> empty.
+        assert!(second_page.is_empty());
+
+        // Let's paginate starting from the beginning (seq > 1)
+        let page_from_beginning = db.query_timeline(None, None, None, Some(1), 2).unwrap();
+        assert_eq!(page_from_beginning.len(), 2);
+        assert_eq!(page_from_beginning[0].seq, Some(2));
+        assert_eq!(page_from_beginning[1].seq, Some(3));
     }
 
     #[test]

--- a/gestalt_cli/src/bus.rs
+++ b/gestalt_cli/src/bus.rs
@@ -4,7 +4,13 @@
 //!
 //! Exposes:
 //! - `POST /api/event`  — any agent pushes a [`BusEvent`] (fire-and-forget)
-//! - `GET  /api/events` — tail of recent bus events from StateDb (dashboard)
+//! - `GET  /api/events` — filtered + paginated tail of recent bus events from StateDb (dashboard)
+//!   Query params:
+//!   - `agent`      (optional) filter by agent ID
+//!   - `event_type` (optional, alias `type`) filter by event kind
+//!   - `project`    (optional) filter by project name
+//!   - `after_seq`  (optional) cursor sequence number for pagination
+//!   - `limit`      (optional) maximum number of events to return (default 50, max 500)
 //! - `GET  /healthz`    — liveness probe for supervisors
 //!
 //! Events are persisted durably in StateDb and streamed to Xavier in real time
@@ -41,7 +47,7 @@ pub fn build_router(state: BusState) -> Router {
 }
 
 /// `POST /api/event` — accept a BusEvent from any agent.
-async fn handle_event_http(
+pub async fn handle_event_http(
     State(state): State<BusState>,
     Json(ev): Json<BusEvent>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
@@ -72,29 +78,41 @@ async fn handle_event_http(
     }
 }
 
-/// `GET /api/events` — tail of recent bus events (chronological).
-async fn list_events_http(
+/// `GET /api/events` — tail of recent bus events with filtering and cursor pagination.
+pub async fn list_events_http(
     State(state): State<BusState>,
     axum::extract::Query(params): axum::extract::Query<EventsQuery>,
 ) -> Result<Json<serde_json::Value>, (axum::http::StatusCode, String)> {
-    let limit = params.limit.unwrap_or(50).min(500);
-    let mut events = state
+    let limit = params.limit.unwrap_or(50).clamp(1, 500);
+    let events = state
         .db
-        .recent_timeline(limit)
+        .query_timeline(
+            params.agent.as_deref(),
+            params.event_type.as_deref(),
+            params.project.as_deref(),
+            params.after_seq,
+            limit,
+        )
         .map_err(|e| (axum::http::StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-    // recent_timeline returns DESC; reverse for chronological order.
-    events.reverse();
+    let next_seq = events.last().and_then(|e| e.seq);
 
     Ok(Json(serde_json::json!({
         "count": events.len(),
         "events": events,
+        "next_seq": next_seq,
+        "cursor": next_seq,
     })))
 }
 
-#[derive(serde::Deserialize)]
-struct EventsQuery {
-    limit: Option<i64>,
+#[derive(serde::Deserialize, Clone)]
+pub struct EventsQuery {
+    pub agent: Option<String>,
+    #[serde(alias = "type")]
+    pub event_type: Option<String>,
+    pub project: Option<String>,
+    pub after_seq: Option<i64>,
+    pub limit: Option<i64>,
 }
 
 /// `GET /healthz` — liveness probe.

--- a/gestalt_cli/tests/bus_api_test.rs
+++ b/gestalt_cli/tests/bus_api_test.rs
@@ -1,0 +1,106 @@
+// Test describe: Gestalt Event Bus Query and Pagination Integration Tests
+// it("should support filtering by agent, type, project and cursor pagination")
+// it("should correctly handle limit query parameters")
+// it("should return the next_seq/cursor pagination indicators")
+
+#[path = "../src/bus.rs"]
+pub mod bus;
+
+use axum::extract::{Query, State};
+use bus::{list_events_http, BusState, EventsQuery};
+use gestalt_router::event_bus::BusEvent;
+use gestalt_state::StateDb;
+use std::sync::Arc;
+
+#[tokio::test]
+async fn it_should_query_events_with_filters_and_pagination() {
+    // Open an in-memory database
+    let db = Arc::new(StateDb::open(":memory:").unwrap());
+    let state = BusState {
+        db: db.clone(),
+        sink: None,
+    };
+
+    // Seed events into StateDb
+    let ev1 = BusEvent::new("agent-a", "run_started", "summary-1")
+        .with_project("project-x");
+    let ev2 = BusEvent::new("agent-b", "checkpoint", "summary-2")
+        .with_project("project-y");
+    let ev3 = BusEvent::new("agent-a", "run_finished", "summary-3")
+        .with_project("project-x");
+
+    gestalt_router::event_bus::persist_event(&db, &ev1).unwrap();
+    gestalt_router::event_bus::persist_event(&db, &ev2).unwrap();
+    gestalt_router::event_bus::persist_event(&db, &ev3).unwrap();
+
+    // 1. Get all events (no filters)
+    let params = EventsQuery {
+        agent: None,
+        event_type: None,
+        project: None,
+        after_seq: None,
+        limit: None,
+    };
+    let response = list_events_http(State(state.clone()), Query(params)).await.unwrap();
+    let json = response.0;
+    assert_eq!(json["count"].as_u64().unwrap(), 3);
+
+    // 2. Filter by project
+    let params = EventsQuery {
+        agent: None,
+        event_type: None,
+        project: Some("project-x".to_string()),
+        after_seq: None,
+        limit: None,
+    };
+    let response = list_events_http(State(state.clone()), Query(params)).await.unwrap();
+    let json = response.0;
+    assert_eq!(json["count"].as_u64().unwrap(), 2);
+    // Parse the payload strings inside events to inspect project
+    let ev_payload_1: serde_json::Value = serde_json::from_str(json["events"][0]["payload"].as_str().unwrap()).unwrap();
+    let ev_payload_2: serde_json::Value = serde_json::from_str(json["events"][1]["payload"].as_str().unwrap()).unwrap();
+    assert_eq!(ev_payload_1["project"].as_str(), Some("project-x"));
+    assert_eq!(ev_payload_2["project"].as_str(), Some("project-x"));
+
+    // 3. Filter by agent
+    let params = EventsQuery {
+        agent: Some("agent-b".to_string()),
+        event_type: None,
+        project: None,
+        after_seq: None,
+        limit: None,
+    };
+    let response = list_events_http(State(state.clone()), Query(params)).await.unwrap();
+    let json = response.0;
+    assert_eq!(json["count"].as_u64().unwrap(), 1);
+    assert_eq!(json["events"][0]["agent_id"].as_str(), Some("agent-b"));
+
+    // 4. Cursor pagination (from sequence 0)
+    let params = EventsQuery {
+        agent: None,
+        event_type: None,
+        project: None,
+        after_seq: Some(0),
+        limit: Some(2),
+    };
+    let response = list_events_http(State(state.clone()), Query(params)).await.unwrap();
+    let json = response.0;
+    assert_eq!(json["count"].as_u64().unwrap(), 2);
+    assert_eq!(json["events"][0]["seq"].as_i64().unwrap(), 1);
+    assert_eq!(json["events"][1]["seq"].as_i64().unwrap(), 2);
+    let cursor = json["next_seq"].as_i64().unwrap();
+    assert_eq!(cursor, 2);
+
+    // Fetch the next page after seq 2
+    let params = EventsQuery {
+        agent: None,
+        event_type: None,
+        project: None,
+        after_seq: Some(cursor),
+        limit: Some(2),
+    };
+    let response = list_events_http(State(state.clone()), Query(params)).await.unwrap();
+    let json = response.0;
+    assert_eq!(json["count"].as_u64().unwrap(), 1);
+    assert_eq!(json["events"][0]["seq"].as_i64().unwrap(), 3);
+}


### PR DESCRIPTION
Implements the filtered and paginated GET /api/events bus query endpoint and supporting StateDb storage capabilities.

Fixes #535

---
*PR created automatically by Jules for task [13461493628804670215](https://jules.google.com/task/13461493628804670215) started by @iberi22*