### PR TITLE
[GES-09] GitCore protocol 3.5.0 to 3.8.0 upgrade

### DIFF
--- a/.github/workflows.disabled/agent-dispatcher.yml
+++ b/.github/workflows.disabled/agent-dispatcher.yml
@@ -1,4 +1,4 @@
-# Git-Core Agent Dispatcher v3.5.1
+# Git-Core Agent Dispatcher v3.8.0
 # Routes issues to best-fit executor agents
 
 name: "Agent Dispatcher"

--- a/.github/workflows.disabled/guardian-agent.yml
+++ b/.github/workflows.disabled/guardian-agent.yml
@@ -1,4 +1,4 @@
-# Git-Core Guardian Agent v3.5.0
+# Git-Core Guardian Agent v3.8.0
 # Auto-merge decisions based on CI/CD and review status
 
 name: "Guardian Agent"

--- a/.github/workflows.disabled/planner-agent.yml
+++ b/.github/workflows.disabled/planner-agent.yml
@@ -1,4 +1,4 @@
-# Git-Core Planner Agent v3.5.0
+# Git-Core Planner Agent v3.8.0
 # Generates atomic issues from ARCHITECTURE.md
 
 name: "Planner Agent"

--- a/.github/workflows/agent-dispatcher.yml
+++ b/.github/workflows/agent-dispatcher.yml
@@ -1,4 +1,4 @@
-# Git-Core Agent Dispatcher v3.5.1
+# Git-Core Agent Dispatcher v3.8.0
 # Routes issues to best-fit executor agents
 
 name: "Agent Dispatcher"

--- a/.github/workflows/guardian-agent.yml
+++ b/.github/workflows/guardian-agent.yml
@@ -1,4 +1,4 @@
-# Git-Core Guardian Agent v3.5.0
+# Git-Core Guardian Agent v3.8.0
 # Auto-merge decisions based on CI/CD and review status
 
 name: "Guardian Agent"

--- a/.github/workflows/planner-agent.yml
+++ b/.github/workflows/planner-agent.yml
@@ -1,4 +1,4 @@
-# Git-Core Planner Agent v3.5.0
+# Git-Core Planner Agent v3.8.0
 # Generates atomic issues from ARCHITECTURE.md
 
 name: "Planner Agent"

--- a/gestalt-router/src/thinking.rs
+++ b/gestalt-router/src/thinking.rs
@@ -150,7 +150,7 @@ impl ThinkingLoop {
             .iter()
             .filter(|e| {
                 let is_execution = e.event_type == "run_finished" || e.event_type == "run_started";
-                let is_newer = last_time.map_or(true, |t| e.created_at > t);
+                let is_newer = last_time.is_none_or(|t| e.created_at > t);
                 is_execution && is_newer
             })
             .count()

--- a/gestalt_cli/src/agent_wrapper.rs
+++ b/gestalt_cli/src/agent_wrapper.rs
@@ -341,7 +341,7 @@ impl AgentWrapper {
             },
             Err(e) => {
                 // Timeout or error: obtain a non-zero exit status dynamically
-                let dummy_status = if e.contains("Timeout") {
+                if e.contains("Timeout") {
                     let mut dcmd = std::process::Command::new("false");
                     let dstatus = dcmd
                         .status()
@@ -353,8 +353,7 @@ impl AgentWrapper {
                         .status()
                         .unwrap_or_else(|_| std::process::ExitStatus::default());
                     (dstatus, String::new(), e.clone(), "Crashed", None)
-                };
-                dummy_status
+                }
             },
         };
 

--- a/gestalt_cli/src/bus.rs
+++ b/gestalt_cli/src/bus.rs
@@ -137,6 +137,7 @@ async fn healthz() -> Json<serde_json::Value> {
 ///
 /// Creates (or opens) the durable StateDb and an optional Xavier sink
 /// (enabled when `XAVIER_TOKEN` is set), then serves until cancelled.
+#[allow(dead_code)]
 pub async fn serve(
     host: &str,
     port: u16,

--- a/gestalt_core/src/search/bm25.rs
+++ b/gestalt_core/src/search/bm25.rs
@@ -123,7 +123,7 @@ impl Bm25Index {
 
     /// Removes a document from the BM25 index.
     pub fn delete_document(&mut self, id: &str) {
-        if let Some(_) = self.documents.remove(id) {
+        if self.documents.remove(id).is_some() {
             if let Some(tokens) = self.doc_tokens.remove(id) {
                 self.total_tokens -= tokens.len();
             }
@@ -243,6 +243,12 @@ impl Bm25Index {
 /// Thread-safe wrapper for `Bm25Index` that implements `LocalSearchEngine`.
 pub struct LocalBm25SearchEngine {
     index: RwLock<Bm25Index>,
+}
+
+impl Default for LocalBm25SearchEngine {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl LocalBm25SearchEngine {


### PR DESCRIPTION
Upgraded GitCore protocol version headers across active and disabled GitHub action workflows to 3.8.0, and resolved workspace clippy lints to ensure clean compilation under `-D warnings`.

Fixes #595

---
*PR created automatically by Jules for task [10608587982681379213](https://jules.google.com/task/10608587982681379213) started by @iberi22*