### PR TITLE
Clean up stale package names in CI

### DIFF
--- a/.github/issues/TASK_jules_release_validation.md
+++ b/.github/issues/TASK_jules_release_validation.md
@@ -17,10 +17,10 @@ Run full release validation after commit `5cf97f9` and close remaining gate evid
 - [ ] `cargo fmt --all --check`
 - [ ] `cargo clippy -p gestalt_core --all-targets -- -D warnings`
 - [ ] `cargo clippy -p gestalt_cli --all-targets -- -D warnings`
-- [ ] `cargo clippy -p gestalt_timeline --all-targets -- -D warnings`
+- [ ] `cargo clippy -p gestalt-state --all-targets -- -D warnings`
 - [ ] `cargo test -p gestalt_core --all-targets`
 - [ ] `cargo test -p gestalt_cli --all-targets`
-- [ ] `cargo test -p gestalt_timeline --lib`
+- [ ] `cargo test -p gestalt-state --lib`
 - [ ] `cargo test --workspace --all-targets` (or split by crate if environment constraints)
 - [ ] `python scripts/compare_benchmarks.py` with benchmark summary attached
 

--- a/.github/workflows.disabled/ci.yml
+++ b/.github/workflows.disabled/ci.yml
@@ -56,8 +56,8 @@ jobs:
           cargo check \
             -p synapse-agentic \
             -p gestalt-merge \
-            -p gestalt_infra_github \
-            -p gestalt_infra_embeddings \
+            -p gestalt_mcp \
+            -p gestalt-proto \
             --all-targets
 
   security-audit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,8 @@ jobs:
           cargo check \
             -p synapse-agentic \
             -p gestalt-merge \
+            -p gestalt_mcp \
+            -p gestalt-proto \
             --all-targets
 
   build-wasm:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,12 @@ jobs:
           cargo test -p gestalt-router --all-targets
           cargo test -p gestalt-state --all-targets
           cargo test -p gestalt-ws --all-targets
+          cargo test -p gestalt-search --all-targets
           cargo check \
             -p synapse-agentic \
             -p gestalt-merge \
+            -p gestalt_mcp \
+            -p gestalt-proto \
             --all-targets
 
       - name: Cargo Build All Features

--- a/gestalt-router/src/thinking.rs
+++ b/gestalt-router/src/thinking.rs
@@ -150,7 +150,7 @@ impl ThinkingLoop {
             .iter()
             .filter(|e| {
                 let is_execution = e.event_type == "run_finished" || e.event_type == "run_started";
-                let is_newer = last_time.map_or(true, |t| e.created_at > t);
+                let is_newer = last_time.is_none_or(|t| e.created_at > t);
                 is_execution && is_newer
             })
             .count()

--- a/gestalt-router/tests/capability_tests.rs
+++ b/gestalt-router/tests/capability_tests.rs
@@ -32,10 +32,10 @@ fn test_agent_capability_matching_intersection() {
         capabilities: vec!["web".to_string(), "search".to_string()],
     };
 
-    let agents = vec![agent_a.clone(), agent_b.clone()];
+    let agents = [agent_a.clone(), agent_b.clone()];
 
     // Filter for capability "code"
-    let req_caps_1 = vec!["code".to_string()];
+    let req_caps_1 = ["code".to_string()];
     let matches_1: Vec<&AgentSpec> = agents
         .iter()
         .filter(|a| req_caps_1.iter().all(|rc| a.capabilities.contains(rc)))
@@ -45,7 +45,7 @@ fn test_agent_capability_matching_intersection() {
     assert_eq!(matches_1[0].id, "agent-a");
 
     // Filter for capabilities "code" AND "test"
-    let req_caps_2 = vec!["code".to_string(), "test".to_string()];
+    let req_caps_2 = ["code".to_string(), "test".to_string()];
     let matches_2: Vec<&AgentSpec> = agents
         .iter()
         .filter(|a| req_caps_2.iter().all(|rc| a.capabilities.contains(rc)))
@@ -55,7 +55,7 @@ fn test_agent_capability_matching_intersection() {
     assert_eq!(matches_2[0].id, "agent-a");
 
     // Filter for capability "web"
-    let req_caps_3 = vec!["web".to_string()];
+    let req_caps_3 = ["web".to_string()];
     let matches_3: Vec<&AgentSpec> = agents
         .iter()
         .filter(|a| req_caps_3.iter().all(|rc| a.capabilities.contains(rc)))
@@ -65,7 +65,7 @@ fn test_agent_capability_matching_intersection() {
     assert_eq!(matches_3[0].id, "agent-b");
 
     // Filter for capabilities "code" AND "web" (disjoint intersection)
-    let req_caps_4 = vec!["code".to_string(), "web".to_string()];
+    let req_caps_4 = ["code".to_string(), "web".to_string()];
     let matches_4: Vec<&AgentSpec> = agents
         .iter()
         .filter(|a| req_caps_4.iter().all(|rc| a.capabilities.contains(rc)))

--- a/gestalt-router/tests/ws_tests.rs
+++ b/gestalt-router/tests/ws_tests.rs
@@ -42,7 +42,7 @@ async fn recv_text(
     ws: &mut (impl StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin),
 ) -> String {
     match tokio::time::timeout(Duration::from_secs(5), ws.next()).await {
-        Ok(Some(Ok(Message::Text(text)))) => text,
+        Ok(Some(Ok(Message::Text(text)))) => text.to_string(),
         Ok(Some(Ok(other))) => panic!("Expected Text frame, got: {other:?}"),
         Ok(Some(Err(e))) => panic!("WebSocket error: {e}"),
         Ok(None) => panic!("WebSocket stream ended unexpectedly"),

--- a/gestalt-ws/tests/integration_tests.rs
+++ b/gestalt-ws/tests/integration_tests.rs
@@ -30,7 +30,7 @@ async fn recv_text(
     ws: &mut (impl StreamExt<Item = Result<Message, tokio_tungstenite::tungstenite::Error>> + Unpin),
 ) -> String {
     match tokio::time::timeout(Duration::from_secs(5), ws.next()).await {
-        Ok(Some(Ok(Message::Text(text)))) => text,
+        Ok(Some(Ok(Message::Text(text)))) => text.to_string(),
         Ok(Some(Ok(other))) => panic!("Expected Text frame, got: {other:?}"),
         Ok(Some(Err(e))) => panic!("WebSocket error: {e}"),
         Ok(None) => panic!("WebSocket stream ended unexpectedly"),

--- a/gestalt_cli/src/agent_wrapper.rs
+++ b/gestalt_cli/src/agent_wrapper.rs
@@ -341,7 +341,7 @@ impl AgentWrapper {
             },
             Err(e) => {
                 // Timeout or error: obtain a non-zero exit status dynamically
-                let dummy_status = if e.contains("Timeout") {
+                if e.contains("Timeout") {
                     let mut dcmd = std::process::Command::new("false");
                     let dstatus = dcmd
                         .status()
@@ -353,8 +353,7 @@ impl AgentWrapper {
                         .status()
                         .unwrap_or_else(|_| std::process::ExitStatus::default());
                     (dstatus, String::new(), e.clone(), "Crashed", None)
-                };
-                dummy_status
+                }
             },
         };
 

--- a/gestalt_cli/src/bus.rs
+++ b/gestalt_cli/src/bus.rs
@@ -137,6 +137,7 @@ async fn healthz() -> Json<serde_json::Value> {
 ///
 /// Creates (or opens) the durable StateDb and an optional Xavier sink
 /// (enabled when `XAVIER_TOKEN` is set), then serves until cancelled.
+#[allow(dead_code)]
 pub async fn serve(
     host: &str,
     port: u16,

--- a/gestalt_cli/tests/agent_exec_test.rs
+++ b/gestalt_cli/tests/agent_exec_test.rs
@@ -22,6 +22,7 @@ fn get_env_mutex() -> &'static std::sync::Mutex<()> {
 }
 
 #[tokio::test]
+#[allow(clippy::await_holding_lock)]
 async fn test_agent_exec_trace_lifecycle() {
     // We synchronize environment modifications using our OnceLock Mutex
     let _env_guard = get_env_mutex().lock().unwrap();

--- a/gestalt_core/src/search/bm25.rs
+++ b/gestalt_core/src/search/bm25.rs
@@ -123,7 +123,7 @@ impl Bm25Index {
 
     /// Removes a document from the BM25 index.
     pub fn delete_document(&mut self, id: &str) {
-        if let Some(_) = self.documents.remove(id) {
+        if self.documents.remove(id).is_some() {
             if let Some(tokens) = self.doc_tokens.remove(id) {
                 self.total_tokens -= tokens.len();
             }
@@ -243,6 +243,12 @@ impl Bm25Index {
 /// Thread-safe wrapper for `Bm25Index` that implements `LocalSearchEngine`.
 pub struct LocalBm25SearchEngine {
     index: RwLock<Bm25Index>,
+}
+
+impl Default for LocalBm25SearchEngine {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl LocalBm25SearchEngine {


### PR DESCRIPTION
Cleaned up stale and deleted package references in CI workflows (.github/workflows/ci.yml, .github/workflows/release.yml, .github/workflows.disabled/ci.yml, and .github/issues/TASK_jules_release_validation.md). Added active workspace packages (gestalt_mcp, gestalt-proto, gestalt-search) to cargo test and cargo check steps and resolved workspace clippy warnings and compiler errors.

Fixes #596

---
*PR created automatically by Jules for task [5512466169946898494](https://jules.google.com/task/5512466169946898494) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling for pending executions.
  * Standardized WebSocket text-message handling for reliable string responses.
  * Updated release validation and quality checks for current packages and search functionality.

* **Refactor**
  * Simplified internal status and document-removal logic.
  * Added default construction support for the local search engine.

* **Tests**
  * Updated capability test data and adjusted integration-test lint handling.
  * Expanded CI and release checks for additional components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->